### PR TITLE
P2.3: offline ETL .coffee → typed TypeScript build scripts

### DIFF
--- a/__tests__/etl/311-aggregate.test.ts
+++ b/__tests__/etl/311-aggregate.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { type ComplaintRecord, aggregateComplaints } from '../../scripts/etl/311/aggregate';
+import { monthKeyToEpoch } from '../../scripts/etl/lib/dates';
+
+const names = { ALL: 'ALL', BK01: 'Greenpoint' };
+const population: Record<string, [unknown, number]> = {
+  BK01: ['Greenpoint', 2000],
+};
+const complaintTypes = { Noise: 'nois' };
+const NOW = Date.parse('2015-01-01T00:00:00-05:00');
+
+const complaints: ComplaintRecord[] = [
+  { complaintType: 'nois', nta: 'BK01', month: 1, year: 2010, hour: 3 },
+  { complaintType: 'nois', nta: 'BK01', month: 1, year: 2010, hour: 4 },
+];
+
+describe('aggregateComplaints', () => {
+  const out = aggregateComplaints(complaints, complaintTypes, names, population, NOW);
+
+  it('rate per 1000 residents (2 / (2000/1000) = 1)', () => {
+    const jan = out.BK01.complaintTally.find((d) => d.date === monthKeyToEpoch('1-2010'));
+    expect(jan?.value).toBe(1);
+  });
+
+  it('ALL -mean SUMS across neighborhoods (non-zero, unlike chicago)', () => {
+    const jan = out.ALL['complaintTally-mean']?.find((d) => d.date === monthKeyToEpoch('1-2010'));
+    // dataTotal = 2 complaints; popTotal = 2000 (only BK01 has pop) -> 2/(2000/1000)=1
+    expect(jan?.value).toBe(1);
+  });
+
+  it('drops years after 2014', () => {
+    const out2 = aggregateComplaints(
+      [{ complaintType: 'nois', nta: 'BK01', month: 1, year: 2015, hour: 1 }],
+      complaintTypes,
+      names,
+      population,
+      NOW,
+    );
+    expect(out2.BK01.complaintTally.every((d) => d.value === 0)).toBe(true);
+  });
+});

--- a/__tests__/etl/bbl.test.ts
+++ b/__tests__/etl/bbl.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatBBL, leftPad } from '../../scripts/etl/lib/bbl';
+
+describe('leftPad', () => {
+  it('zero-pads to the target length', () => {
+    expect(leftPad(63, 5)).toBe('00063');
+    expect(leftPad('119', 4)).toBe('0119');
+  });
+  it('leaves values already at/over length unchanged', () => {
+    expect(leftPad(12345, 5)).toBe('12345');
+    expect(leftPad(123456, 5)).toBe('123456');
+  });
+});
+
+describe('formatBBL', () => {
+  it('builds a 10-char borough+block+lot key', () => {
+    // borough 3 (Brooklyn), block 6363, lot 119 -> 3 06363 0119
+    expect(formatBBL(3, 6363, 119)).toBe('3063630119');
+  });
+});

--- a/__tests__/etl/brooklyn-aggregate.test.ts
+++ b/__tests__/etl/brooklyn-aggregate.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { aggregateSales, normalizeSale } from '../../scripts/etl/brooklyn/aggregate';
+import { quarterKeyToEpoch } from '../../scripts/etl/lib/dates';
+
+const DATA_DIR = join(process.cwd(), 'public/data/brooklyn');
+const ntaCodes = Object.keys(
+  JSON.parse(readFileSync(join(DATA_DIR, 'nyc-neighborhood-names.json'), 'utf8')),
+);
+const buildingClassKeys = Object.keys(
+  JSON.parse(readFileSync(join(DATA_DIR, 'building-class.json'), 'utf8')),
+);
+
+describe('normalizeSale', () => {
+  it('derives quarter/year and pricePerSqFt, trims building class', () => {
+    const s = normalizeSale({
+      buildingCl: '01  ONE FAMILY DWELLINGS',
+      residentia: 1,
+      commercial: 0,
+      ntacode: 'BK27',
+      price: '$400,000',
+      grossSqFt: '1,000',
+      date: quarterKeyToEpoch('1-2003'),
+    });
+    expect(s.buildingClass).toBe('01  ONE FAMILY DWELLINGS');
+    expect(s.quarter).toBe(1);
+    expect(s.year).toBe(2003);
+    expect(s.pricePerSqFt).toBe(400);
+  });
+
+  it('excludes pricePerSqFt for implausible sqft/price (legacy rules)', () => {
+    expect(
+      normalizeSale({ price: '$5,000', grossSqFt: '1,000', date: 0 }).pricePerSqFt,
+    ).toBeUndefined();
+    expect(
+      normalizeSale({ price: '$400,000', grossSqFt: '100', date: 0 }).pricePerSqFt,
+    ).toBeUndefined();
+  });
+});
+
+describe('aggregateSales', () => {
+  const out = aggregateSales(
+    [
+      {
+        buildingCl: '01 ONE FAMILY',
+        residentia: 1,
+        commercial: 0,
+        ntacode: 'BK27',
+        price: '$400,000',
+        grossSqFt: '1,000',
+        date: quarterKeyToEpoch('1-2003'),
+      },
+      {
+        buildingCl: '01 ONE FAMILY',
+        residentia: 1,
+        commercial: 0,
+        ntacode: 'BK27',
+        price: '$600,000',
+        grossSqFt: '1,000',
+        date: quarterKeyToEpoch('1-2003'),
+      },
+    ],
+    ntaCodes,
+    buildingClassKeys,
+  );
+
+  it('produces a 48-point quarterly axis (2003-2014) per NTA', () => {
+    expect(out.BK27.residentialPrices).toHaveLength(48);
+  });
+
+  it('means pricePerSqFt within a quarter (mean(400,600)=500)', () => {
+    const q1 = out.BK27.residentialPrices.find((d) => d.date === quarterKeyToEpoch('1-2003'));
+    expect(q1?.value).toBe(500);
+  });
+
+  it('emits the special ALL (-mean) and BK73 (williamsburgTrend) series', () => {
+    expect(out.ALL['residentialPrices-mean']).toBeDefined();
+    expect(out.BK73.williamsburgTrend).toBeDefined();
+    expect(out.BK27.williamsburgTrend).toBeUndefined();
+  });
+
+  it('matches the committed display-data date axis exactly', () => {
+    const committed = JSON.parse(
+      readFileSync(join(DATA_DIR, 'brooklyn-sales-display-data.json'), 'utf8'),
+    );
+    const expectedDates = committed.ALL.residentialPrices.map((d: { date: number }) => d.date);
+    const actualDates = out.ALL.residentialPrices.map((d) => d.date);
+    expect(actualDates).toEqual(expectedDates);
+  });
+});

--- a/__tests__/etl/brooklyn-geocode.test.ts
+++ b/__tests__/etl/brooklyn-geocode.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { type RawSale, geocodeSales } from '../../scripts/etl/brooklyn/geocode';
+
+describe('geocodeSales', () => {
+  const bblToLatLong = { '3063630119': [40.6, -73.9] as [number, number] };
+  const blockLotToBbl = { '6363-119': '3063630119' };
+
+  it('attaches coordinates via block-lot -> bbl -> lat/long and emits a FeatureCollection', () => {
+    const sales: RawSale[] = [
+      {
+        BLOCK: 6363,
+        LOT: 119,
+        'BUILDING CLASS CATEGORY': ' 01 ONE FAMILY ',
+        'SALE PRICE': '$670,000',
+        'SALE DATE': '2014-04-16',
+      },
+    ];
+    const { collection, stats } = geocodeSales(sales, bblToLatLong, blockLotToBbl);
+    expect(stats).toMatchObject({ total: 1, success: 1, fail: 0 });
+    expect(collection.features).toHaveLength(1);
+    const f = collection.features[0];
+    expect(f.properties.bbl).toBe('3063630119');
+    expect(f.properties.buildingClass).toBe('01 ONE FAMILY');
+    // geometry is [y, x] = [long, lat] per the legacy code
+    expect(f.geometry.coordinates).toEqual([-73.9, 40.6]);
+  });
+
+  it('drops sales that do not resolve to coordinates', () => {
+    const sales: RawSale[] = [{ BLOCK: 9999, LOT: 1, 'SALE DATE': '2014-01-01' }];
+    const { collection, stats } = geocodeSales(sales, bblToLatLong, blockLotToBbl);
+    expect(stats.fail).toBe(1);
+    expect(collection.features).toHaveLength(0);
+  });
+});

--- a/__tests__/etl/chicago-aggregate.test.ts
+++ b/__tests__/etl/chicago-aggregate.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { type CrimeRecord, aggregateCrimes } from '../../scripts/etl/chicago/aggregate';
+import { monthKeyToEpoch } from '../../scripts/etl/lib/dates';
+
+const names = { ALL: 'ALL', '1': 'Loop' };
+const population = { Loop: { 'TOTAL-2010': 1000 } };
+const crimeTypes = { THEFT: 'THE' };
+const NOW = Date.parse('2015-01-01T00:00:00-05:00');
+
+const crimes: CrimeRecord[] = [
+  { crimeType: 'THE', nta: '1', month: 1, year: 2003, hour: 5 },
+  { crimeType: 'THE', nta: '1', month: 1, year: 2003, hour: 6 },
+  { crimeType: 'THE', nta: '1', month: 1, year: 2003, hour: 7 },
+];
+
+describe('aggregateCrimes', () => {
+  const out = aggregateCrimes(crimes, crimeTypes, names, population, NOW);
+
+  it('rate = count per 1000 residents (3 crimes / (1000/1000) = 3)', () => {
+    const jan = out['1'].crimeTally.find((d) => d.date === monthKeyToEpoch('1-2003'));
+    expect(jan?.value).toBe(3);
+  });
+
+  it('drops out-of-range years', () => {
+    const out2 = aggregateCrimes(
+      [{ crimeType: 'THE', nta: '1', month: 1, year: 2020, hour: 1 }],
+      crimeTypes,
+      names,
+      population,
+      NOW,
+    );
+    expect(out2['1'].crimeTally.every((d) => d.value === 0)).toBe(true);
+  });
+
+  it('reproduces the legacy all-zero ALL series (scalar _.reduce quirk)', () => {
+    expect(out.ALL.crimeTally.every((d) => d.value === 0)).toBe(true);
+    expect(out.ALL['crimeTally-mean']?.every((d) => d.value === 0)).toBe(true);
+  });
+
+  it('emits a 24-point hour-of-day series per valid crime type', () => {
+    expect(out['1'].crimeType.THE).toHaveLength(24);
+  });
+});

--- a/__tests__/etl/dates-monthly.test.ts
+++ b/__tests__/etl/dates-monthly.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { hourEpoch, monthKeyToEpoch } from '../../scripts/etl/lib/dates';
+
+describe('monthKeyToEpoch', () => {
+  it('matches the committed chicago/311 monthly axis (America/New_York)', () => {
+    // Verified against public/data/chicago/chicago-crimes-display-data.json.
+    expect(monthKeyToEpoch('1-2003')).toBe(1041397200000);
+    expect(monthKeyToEpoch('2-2003')).toBe(1044075600000);
+  });
+  it('throws on an invalid month', () => {
+    expect(() => monthKeyToEpoch('13-2003')).toThrow();
+  });
+});
+
+describe('hourEpoch', () => {
+  it('is deterministic for a fixed reference date (NY-local hour of that day)', () => {
+    const ref = Date.parse('2015-06-15T12:00:00-04:00'); // EDT
+    const noon = hourEpoch(12, ref);
+    const onePm = hourEpoch(13, ref);
+    expect(onePm - noon).toBe(3600000);
+    // 12:00 EDT on 2015-06-15 == 16:00 UTC
+    expect(new Date(noon).toISOString()).toBe('2015-06-15T16:00:00.000Z');
+  });
+});

--- a/__tests__/etl/dates.test.ts
+++ b/__tests__/etl/dates.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveSaleDateParts,
+  quarterKeyToEpoch,
+  yearKeyToEpoch,
+} from '../../scripts/etl/lib/dates';
+
+describe('quarterKeyToEpoch', () => {
+  it('matches the committed display-data date axis (fixed UTC-5, no DST)', () => {
+    // Verified against apps/brooklyn committed brooklyn-sales-display-data.json.
+    expect(quarterKeyToEpoch('1-2003')).toBe(1041397200000);
+    expect(quarterKeyToEpoch('2-2003')).toBe(1049173200000);
+  });
+
+  it('Q2 is exactly +90 days from Q1 2003 (constant offset, not DST-shifted)', () => {
+    expect(quarterKeyToEpoch('2-2003') - quarterKeyToEpoch('1-2003')).toBe(90 * 86400000);
+  });
+
+  it('throws on an invalid quarter', () => {
+    expect(() => quarterKeyToEpoch('5-2003')).toThrow();
+  });
+});
+
+describe('yearKeyToEpoch', () => {
+  it('returns the start of the year at UTC-5', () => {
+    expect(yearKeyToEpoch('2003')).toBe(Date.UTC(2003, 0, 1, 5));
+    expect(yearKeyToEpoch(2010)).toBe(Date.UTC(2010, 0, 1, 5));
+  });
+});
+
+describe('deriveSaleDateParts', () => {
+  it('derives quarter/month/year for a Q1 instant', () => {
+    expect(deriveSaleDateParts(quarterKeyToEpoch('1-2003'))).toEqual({
+      quarter: 1,
+      month: 0,
+      year: 2003,
+    });
+  });
+
+  it('derives Q4 for an October instant', () => {
+    expect(deriveSaleDateParts(quarterKeyToEpoch('4-2014'))).toEqual({
+      quarter: 4,
+      month: 9,
+      year: 2014,
+    });
+  });
+});

--- a/__tests__/etl/initials.test.ts
+++ b/__tests__/etl/initials.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { getInitials } from '../../scripts/etl/lib/initials';
+
+describe('getInitials', () => {
+  it('concatenates the first len chars of each word (multi-word)', () => {
+    expect(getInitials('Rat Sighting', 3)).toBe('RatSig');
+    expect(getInitials('Heat Hot Water')).toBe('HeHoWa');
+  });
+  it('takes len+1 chars for a single word', () => {
+    expect(getInitials('Rodent', 3)).toBe('Rode');
+    expect(getInitials('Noise')).toBe('Noi');
+  });
+});

--- a/__tests__/etl/north-carolina-aggregate.test.ts
+++ b/__tests__/etl/north-carolina-aggregate.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type CensusFeature,
+  type RawVote,
+  getDistrictData,
+  tallyVotesByPrecinct,
+} from '../../scripts/etl/north-carolina/aggregate';
+
+const votes: RawVote[] = [
+  { precinct_abbrv: 'P1', party_cd: 'DEM', total_voters: 60 },
+  { precinct_abbrv: 'P1', party_cd: 'REP', total_voters: 40 },
+];
+
+describe('tallyVotesByPrecinct', () => {
+  it('sums voters per party and total', () => {
+    const t = tallyVotesByPrecinct(votes);
+    expect(t.P1).toMatchObject({ DEM: 60, REP: 40, total: 100 });
+  });
+});
+
+describe('getDistrictData', () => {
+  const features: CensusFeature[] = [
+    {
+      geometry: { coordinates: [-77.6, 35.1] },
+      properties: {
+        district: '3',
+        GEOID: '371070114003',
+        prec_id: 'P1',
+        B01001e1: 1127,
+        B02001e2: 987,
+        B15002e15: 30,
+        B15002e32: 35,
+      },
+    },
+    { geometry: {}, properties: { district: '4' } }, // no coordinates
+  ];
+
+  const out = getDistrictData(features, votes);
+
+  it('returns undefined for features without coordinates', () => {
+    expect(out[1]).toBeUndefined();
+  });
+
+  it('maps census keys, sums bachelors, and computes vote share', () => {
+    const block = out[0]!;
+    expect(block.district).toBe('3');
+    expect(block.pop).toBe(1127);
+    expect(block.white).toBe(987);
+    expect(block.bachelors).toBe(65);
+    expect(block.democrat).toBeCloseTo(60);
+    expect(block.republican).toBeCloseTo(40);
+  });
+});

--- a/docs/etl.md
+++ b/docs/etl.md
@@ -1,0 +1,82 @@
+# Offline ETL — raw data → display JSON
+
+The visualization pages load small, pre-aggregated **display JSON** from
+`public/data/<app>/`. That display JSON is produced **offline** from large raw
+datasets — it is not computed in the browser. This doc covers the migration of
+the legacy CoffeeScript ETL (`apps/*/format-data.coffee`,
+`apps/*/script/format-display-data.coffee`, `apps/brooklyn/geocode-sales.coffee`)
+to typed, tsx-runnable TypeScript under `scripts/etl/` (MIGRATION.md §2.3).
+
+## ⚠️ Raw inputs are not in the repo
+
+Every legacy pipeline consumes a **gitignored raw dataset that is not present in
+this working tree** (they were processed locally years ago and never committed):
+
+| App | Raw input (gitignored, absent) | Output (committed) |
+|-----|-------------------------------|--------------------|
+| brooklyn | `apps/brooklyn/data/brooklyn-sales.json` (geocoded sales GeoJSON) | `public/data/brooklyn/brooklyn-sales-display-data.json` |
+| 311 | `apps/311/data/311-by-neighborhood.json` (line-delimited features) | `public/data/311/display-data.json` |
+| chicago | `apps/chicago/data/crimes.csv` | `public/data/chicago/chicago-crimes-display-data.json` |
+| north-carolina | `apps/north-carolina/data/census-block-by-district.json` + `vote-tally.json` | `public/data/north-carolina/display-data.json` |
+
+Because the raws are absent, the display JSON **cannot be regenerated
+byte-for-byte here right now**. The committed display JSON is the **canonical
+source of truth** (confirmed with the maintainer). The ported TS reproduces the
+legacy logic and will rebuild the outputs once a raw dataset is supplied (drop it
+at the path above and run the script). Each build step exits with a clear error
+if its raw input is missing.
+
+> **Provenance gap:** sourcing the raw datasets for a one-time real regen +
+> byte-diff verification is tracked in
+> [GitHub issue #15](https://github.com/zamiang/vislet/issues/15).
+
+The ETL **transform logic is unit-tested** (`__tests__/etl/`) using synthetic
+fixtures, and the brooklyn date axis is validated against the committed display
+data — so correctness is covered without needing the raws.
+
+## The 12 MB `bbl-to-lat-long.json` — already client-safe
+
+A migration concern was keeping the 12 MB `bbl-to-lat-long.json` out of the
+client bundle. Investigation shows it **already never ships to the client**: the
+brooklyn client (`apps/brooklyn/client/index.coffee`) loads only the aggregate
+display data + `brooklyn.json` (neighborhood topojson). `bbl-to-lat-long.json`
+and `block-lot-to-bbl.json` are used **only** in the offline geocoding step
+(`geocode-sales.coffee`): raw sales × bbl-hash → per-sale lat/long → GeoJSON,
+which is then aggregated. The map is a **choropleth** (neighborhoods colored by
+aggregate), not individual points. So there is no client-side lat/long join to
+move to build time — the offline geocode step is ported for completeness/repro
+only. (Confirm with the page/chart work if a future brooklyn view needs per-sale
+points.)
+
+## Layout
+
+```
+scripts/etl/
+├── build.ts                 # `npm run data:build` — runs every app's build step
+├── lib/
+│   ├── dates.ts             # quarter/year key → epoch (America/New_York, DST-aware)
+│   ├── bbl.ts               # Borough-Block-Lot helpers (port of numberutils/bbl)
+│   └── initials.ts          # complaint/crime initials (port of datautil/get-initials)
+└── brooklyn/
+    ├── aggregate.ts         # typed port of collections/sales.coffee getSalesData
+    └── build.ts             # `npm run data:build:brooklyn` — raw GeoJSON → display JSON
+```
+
+311 / chicago / north-carolina aggregation modules are ported in follow-ups
+(pending the data-source decision — see the hive query on p2.3-etl).
+
+## Running
+
+```bash
+npm run data:build            # all apps (errors per step on missing raw input)
+npm run data:build:brooklyn   # brooklyn only
+npm test -- __tests__/etl     # ETL unit tests
+```
+
+### Date handling note
+
+The legacy Moment code generated dates in **America/New_York** local time
+(DST-aware). `lib/dates.ts` reproduces this via the `Intl` API rather than a
+fixed offset, because DST membership of e.g. April 1 varies by year (pre-2007 US
+DST started in April, so Apr 1 2003–2006 was EST while Apr 1 2013 was EDT). This
+makes the output match the committed date axis on any build host.

--- a/knip.json
+++ b/knip.json
@@ -1,12 +1,10 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
-  "entry": ["src/pages/**/*.{ts,astro}", "src/layouts/**/*.astro"],
-  "project": ["src/**/*.{ts,tsx,astro}", "__tests__/**/*.{ts,tsx}"],
+  "entry": ["src/pages/**/*.{ts,astro}", "src/layouts/**/*.astro", "scripts/etl/**/build.ts"],
+  "project": ["src/**/*.{ts,tsx,astro}", "scripts/**/*.ts", "__tests__/**/*.{ts,tsx}"],
   "ignore": ["src/types/index.ts"],
   "ignoreDependencies": [
     "tailwindcss",
-    "d3",
-    "@types/d3",
     "topojson-client",
     "@types/topojson-client",
     "@testing-library/dom",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "postcss": "8.5.15",
         "prettier": "3.8.3",
         "prettier-plugin-astro": "0.14.1",
+        "tsx": "4.20.6",
         "typescript": "6.0.3",
         "typescript-eslint": "8.60.1",
         "vite-tsconfig-paths": "6.1.1",
@@ -10448,6 +10449,497 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/tsx/node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "test:watch": "vitest --watch",
     "typecheck": "tsc --noEmit",
     "data:build": "tsx scripts/etl/build.ts",
-    "data:build:brooklyn": "tsx scripts/etl/brooklyn/build.ts"
+    "data:build:brooklyn": "tsx scripts/etl/brooklyn/build.ts",
+    "data:build:311": "tsx scripts/etl/311/build.ts",
+    "data:build:chicago": "tsx scripts/etl/chicago/build.ts",
+    "data:build:north-carolina": "tsx scripts/etl/north-carolina/build.ts"
   },
   "dependencies": {
     "@astrojs/react": "5.0.7",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "data:build": "tsx scripts/etl/build.ts",
+    "data:build:brooklyn": "tsx scripts/etl/brooklyn/build.ts"
   },
   "dependencies": {
     "@astrojs/react": "5.0.7",
@@ -52,6 +54,7 @@
     "postcss": "8.5.15",
     "prettier": "3.8.3",
     "prettier-plugin-astro": "0.14.1",
+    "tsx": "4.20.6",
     "typescript": "6.0.3",
     "typescript-eslint": "8.60.1",
     "vite-tsconfig-paths": "6.1.1",

--- a/scripts/etl/311/aggregate.ts
+++ b/scripts/etl/311/aggregate.ts
@@ -1,0 +1,168 @@
+/**
+ * NYC 311 aggregation — typed port of
+ * `apps/311/script/format-display-data.coffee` (`getData`).
+ *
+ * Pure function of its inputs. Produces the 311 `display-data.json` shape:
+ * per-neighborhood monthly complaint rate (per 1,000 residents) + the ALL
+ * (-mean) series (which sums across neighborhoods), plus a per-complaint-type
+ * hour-of-day rate series.
+ *
+ * Differs from chicago in the population lookup: 311 keys population by NTA code
+ * directly and reads index [1]; its ALL -mean sums an array (so it is non-zero),
+ * whereas chicago's collapses to zero — both faithful to the legacy code.
+ */
+import { hourEpoch, monthKeyToEpoch } from '../lib/dates';
+
+export interface ComplaintRecord {
+  complaintType: string;
+  nta: string;
+  month: number;
+  year: number;
+  hour: number;
+}
+
+export interface DateValue {
+  date: number;
+  value: number;
+}
+
+export interface NeighborhoodComplaintData {
+  complaintTally: DateValue[];
+  complaintType: Record<string, DateValue[]>;
+  'complaintTally-mean'?: DateValue[];
+}
+
+export type ThreeOneOneDisplayData = Record<string, NeighborhoodComplaintData>;
+
+/** Population keyed by NTA code; value is a tuple where index 1 is the count. */
+type Population = Record<string, [unknown, number]>;
+
+const MONTHS = Array.from({ length: 12 }, (_, i) => i + 1);
+const YEARS = Array.from({ length: 2014 - 2010 + 1 }, (_, i) => 2010 + i);
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+const COMPLAINTS_DATA_KEYS = ['complaintTally'] as const;
+const VALID_COMPLAINT_TYPES = [
+  'illpar',
+  'watsys',
+  'blodri',
+  'derveh',
+  'sewe',
+  'strligcon',
+  'trasigcon',
+  'deatre',
+  'sancon',
+  'heat',
+  'dircon',
+  'miscol',
+  'buil',
+  'concom',
+  'rode',
+  'nois',
+  'bromunmet',
+  'taxcom',
+];
+
+interface ComplaintAccumulator {
+  complaintTally: Record<string, number>;
+  complaintType: Record<number, Record<string, number>>;
+}
+
+function monthKeys(): string[] {
+  const keys: string[] = [];
+  for (const year of YEARS) for (const month of MONTHS) keys.push(`${month}-${year}`);
+  return keys;
+}
+
+const formatDecimal = (n: number): number => Number(Number(n).toFixed(2));
+
+/**
+ * @param complaints  parsed complaint records
+ * @param complaintTypes  map of complaint-name -> code (complaint-types.json)
+ * @param neighborhoodNames  NTA-code -> name (used only for the key set)
+ * @param population  population keyed by NTA code (index 1 = count)
+ * @param nowMs       reference date for the (legacy non-deterministic) hour axis
+ */
+export function aggregateComplaints(
+  complaints: ComplaintRecord[],
+  complaintTypes: Record<string, string>,
+  neighborhoodNames: Record<string, string>,
+  population: Population,
+  nowMs: number,
+): ThreeOneOneDisplayData {
+  const typeKeys = Object.keys(complaintTypes).map((name) => complaintTypes[name]);
+  const ntaCodes = Object.keys(neighborhoodNames);
+
+  const data: Record<string, ComplaintAccumulator> = {};
+  for (const key of ntaCodes) {
+    const complaintTally: Record<string, number> = {};
+    for (const k of monthKeys()) complaintTally[k] = 0;
+    const complaintType: Record<number, Record<string, number>> = {};
+    for (const hour of HOURS) {
+      complaintType[hour] = {};
+      for (const t of typeKeys) complaintType[hour][t] = 0;
+    }
+    data[key] = { complaintTally, complaintType };
+  }
+
+  for (const c of complaints) {
+    const bucket = data[c.nta];
+    if (!bucket) continue;
+    if (c.year > 2014) continue;
+    const dateKey = `${c.month}-${c.year}`;
+    if (bucket.complaintTally[dateKey] !== undefined) bucket.complaintTally[dateKey]++;
+    if (c.complaintType && c.complaintType.length > 0) {
+      const hourBucket = bucket.complaintType[c.hour];
+      if (hourBucket && hourBucket[c.complaintType] !== undefined) hourBucket[c.complaintType]++;
+    }
+  }
+
+  const averageByPopulation = (value: number | number[], nta: string): number => {
+    if (nta === 'ALL') {
+      const popTotal = ntaCodes.reduce((sum, name) => sum + (population[name]?.[1] ?? 0), 0);
+      const dataTotal = Array.isArray(value) ? value.reduce((a, b) => a + b, 0) : 0;
+      return formatDecimal(dataTotal / (popTotal / 1000));
+    }
+    const pop = population[nta]?.[1] ?? 0;
+    const v = typeof value === 'number' ? value : 0;
+    if (v < 1 || pop < 1) return 0;
+    return formatDecimal(v / (pop / 1000));
+  };
+
+  const formatted: ThreeOneOneDisplayData = {};
+  for (const ntaID of ntaCodes) {
+    const flattened: NeighborhoodComplaintData = { complaintTally: [], complaintType: {} };
+
+    for (const key of COMPLAINTS_DATA_KEYS) {
+      const series = data[ntaID][key];
+      flattened[key] = Object.keys(series).map((dateKey) => ({
+        date: monthKeyToEpoch(dateKey),
+        value: averageByPopulation(series[dateKey], ntaID),
+      }));
+
+      if (ntaID === 'ALL') {
+        // getComplaintTotals pushes each NTA's monthly count into an array per
+        // month-key; the ALL -mean sums that array (=> non-zero, unlike chicago).
+        const totals: Record<string, number[]> = {};
+        for (const id of ntaCodes) {
+          const s = data[id][key];
+          for (const itemKey of Object.keys(s)) (totals[itemKey] ||= []).push(s[itemKey]);
+        }
+        flattened[`${key}-mean`] = Object.keys(totals).map((totalKey) => ({
+          date: monthKeyToEpoch(totalKey),
+          value: averageByPopulation(totals[totalKey], ntaID),
+        }));
+      }
+    }
+
+    flattened.complaintType = {};
+    for (const type of VALID_COMPLAINT_TYPES) {
+      flattened.complaintType[type] = HOURS.map((hour) => ({
+        date: hourEpoch(hour, nowMs),
+        value: averageByPopulation(data[ntaID].complaintType[hour][type], ntaID),
+      }));
+    }
+    formatted[ntaID] = flattened;
+  }
+
+  return formatted;
+}

--- a/scripts/etl/311/build.ts
+++ b/scripts/etl/311/build.ts
@@ -1,0 +1,66 @@
+/**
+ * 311 display-data build (tsx-runnable). Reads the line-delimited GeoJSON-ish
+ * 311 export, parses to complaint records, aggregates, writes the display JSON.
+ *
+ * Raw input (apps/311/data/311-by-neighborhood.json) is gitignored/absent
+ * (issue #15) — exits with a clear error until supplied. Parsing mirrors the
+ * legacy line reader (apps/311/format-data.coffee).
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { getInitials } from '../lib/initials';
+import { type ComplaintRecord, aggregateComplaints } from './aggregate';
+
+const ROOT = process.cwd();
+const RAW = join(ROOT, 'apps/311/data/311-by-neighborhood.json');
+const D = join(ROOT, 'public/data/311');
+const OUT = join(D, 'display-data.json');
+
+function normalizeInitials(raw: string): string {
+  let i = getInitials(raw, 3).toLowerCase();
+  if (i === 'heawat') i = 'heat';
+  if (i === 'damtre' || i === 'ovetre') i = 'deatre';
+  if (i === 'miscol(almat') i = 'miscol';
+  if (i === 'noi-con' || i === 'noi-str') i = 'nois';
+  return i;
+}
+
+function main(): void {
+  if (!existsSync(RAW)) {
+    console.error(`Raw input not found: ${RAW}\nGitignored/absent — see docs/etl.md (issue #15).`);
+    process.exitCode = 1;
+    return;
+  }
+  const lines = readFileSync(RAW, 'utf8').split('\n');
+  const records: ComplaintRecord[] = [];
+  for (const line of lines) {
+    if (line.length <= 1) continue;
+    const json = JSON.parse(line.replace('} },', '} }')).properties;
+    const d = new Date(json['Created Da']);
+    const year = d.getFullYear();
+    if (year > 2009 && year < 2015) {
+      records.push({
+        complaintType: normalizeInitials(json['Complaint']),
+        nta: json.ntacode,
+        month: d.getMonth() + 1,
+        year,
+        hour: d.getHours(),
+      });
+    }
+  }
+  const complaintTypes = JSON.parse(readFileSync(join(D, 'complaint-types.json'), 'utf8'));
+  const names = JSON.parse(readFileSync(join(D, 'nyc-neighborhood-names.json'), 'utf8'));
+  const population = JSON.parse(readFileSync(join(D, 'population.json'), 'utf8'));
+  const display = aggregateComplaints(
+    records,
+    complaintTypes,
+    names,
+    population,
+    Date.parse('2015-01-01T00:00:00-05:00'),
+  );
+  writeFileSync(OUT, JSON.stringify(display));
+  console.log(`Wrote ${OUT} (${records.length} complaints)`);
+}
+
+main();

--- a/scripts/etl/brooklyn/aggregate.ts
+++ b/scripts/etl/brooklyn/aggregate.ts
@@ -1,0 +1,298 @@
+/**
+ * Brooklyn property-sales aggregation — typed port of the legacy
+ * `apps/brooklyn/collections/sales.coffee` (`getSalesData`) and the per-sale
+ * normalization in `apps/brooklyn/models/sale.coffee`.
+ *
+ * Pure functions of their inputs (no Backbone, no DOM). The output object is the
+ * `brooklyn-sales-display-data.json` consumed by the brooklyn page: per-NTA
+ * quarterly residential price means + building-class percentages, plus the
+ * special "ALL" (-mean) and "BK73" (williamsburgTrend) series.
+ *
+ * Reproduces the committed display data's structure and date axis; see
+ * docs/etl.md for the raw-input situation.
+ */
+import { ascending, mean, quantile } from 'd3';
+
+import { deriveSaleDateParts, quarterKeyToEpoch, yearKeyToEpoch } from '../lib/dates';
+
+/** Raw sale properties as read by the legacy `Sale` model (shapefile-truncated names). */
+export interface RawSaleProperties {
+  /** Building class category string, e.g. "01  ONE FAMILY DWELLINGS". */
+  buildingCl?: string;
+  /** Residential unit count. */
+  residentia?: number;
+  /** Commercial unit count. */
+  commercial?: number;
+  /** Neighborhood tabulation area code, e.g. "BK27". */
+  ntacode?: string;
+  /** Sale price; may be a "$670,000"-style string or a number. */
+  price?: string | number;
+  /** Gross square feet; may be a "1,492"-style string or a number. */
+  grossSqFt?: string | number;
+  /** Sale date as epoch ms. */
+  date?: number;
+}
+
+/** A sale after normalization (mirrors `Sale` post-`initialize`). */
+interface NormalizedSale {
+  buildingClass: string;
+  residentia: number;
+  commercial: number;
+  ntacode?: string;
+  pricePerSqFt?: number;
+  quarter: number;
+  year: number;
+}
+
+export interface DateValue {
+  date: number;
+  value: number;
+}
+export interface TrendPoint {
+  date: number;
+  pct25: number;
+  value: number;
+  pct75: number;
+}
+
+/** Per-NTA display series. Extra keys ("…-mean", "williamsburgTrend") are conditional. */
+export interface NeighborhoodDisplayData {
+  residentialPrices: DateValue[];
+  buildingClass: Record<string, DateValue[]>;
+  'residentialPrices-mean'?: DateValue[];
+  williamsburgTrend?: TrendPoint[];
+}
+
+export type BrooklynDisplayData = Record<string, NeighborhoodDisplayData>;
+
+const QUARTERS = [1, 2, 3, 4];
+const YEARS = Array.from({ length: 2014 - 2003 + 1 }, (_, i) => 2003 + i);
+const SALES_DATA_KEYS = ['residentialPrices'] as const;
+// Excludes "16", "17", "23" (very uncommon in Brooklyn), per the legacy comment.
+const VALID_RESIDENTIAL_BUILDING_CLASSES = [
+  '01',
+  '02',
+  '03',
+  '04',
+  '07',
+  '08',
+  '09',
+  '10',
+  '12',
+  '13',
+  '15',
+  '28',
+];
+
+/** Insertion order matches `createQuarterlyHash`: year-major, quarter-minor. */
+function quarterKeys(): string[] {
+  const keys: string[] = [];
+  for (const year of YEARS) for (const quarter of QUARTERS) keys.push(`${quarter}-${year}`);
+  return keys;
+}
+
+interface NtaAccumulator {
+  residentialSaleTally: Record<string, number>;
+  residentialPrices: Record<string, number[]>;
+  commercialSaleTally: Record<string, number>;
+  commercialPrices: Record<string, number[]>;
+  buildingClass: Record<string, Record<string, number>>;
+}
+
+/** Normalize a raw sale (port of `Sale.initialize` + `setupDate`/`setupPricePerSqFt`). */
+export function normalizeSale(raw: RawSaleProperties): NormalizedSale {
+  const buildingClass = (raw.buildingCl ?? '').trim();
+  const { quarter, year } = deriveSaleDateParts(raw.date ?? 0);
+
+  const sale: NormalizedSale = {
+    buildingClass,
+    residentia: Number(raw.residentia ?? 0),
+    commercial: Number(raw.commercial ?? 0),
+    ntacode: raw.ntacode,
+    quarter,
+    year,
+  };
+
+  // setupPricePerSqFt with the legacy exclusion rules.
+  if (raw.price && raw.grossSqFt) {
+    const price = Number(String(raw.price).replace(/[$,]/g, ''));
+    const sqft = Number(String(raw.grossSqFt).replace(/,/g, ''));
+    const MIN_SQFT = 300;
+    const MAX_SQFT = 10000;
+    const MIN_PRICE = 10000;
+    if (!(sqft > MAX_SQFT || sqft < MIN_SQFT || price < MIN_PRICE) && price / sqft >= 30) {
+      sale.pricePerSqFt = price / sqft;
+    }
+  }
+  return sale;
+}
+
+function createQuarterlyHash<T extends number | number[]>(empty: () => T): Record<string, T> {
+  const hash: Record<string, T> = {};
+  for (const key of quarterKeys()) hash[key] = empty();
+  return hash;
+}
+
+function createYearlyBuildingClassHash(
+  buildingClassKeys: string[],
+): Record<string, Record<string, number>> {
+  const hash: Record<string, Record<string, number>> = {};
+  for (const year of YEARS) {
+    hash[String(year)] = {};
+    for (const bc of buildingClassKeys) hash[String(year)][bc] = 0;
+  }
+  return hash;
+}
+
+/**
+ * Aggregate normalized sales into the brooklyn display-data structure.
+ *
+ * @param sales      raw sale properties (as the legacy `Sale` model reads them)
+ * @param ntaCodes   neighborhood codes incl. "ALL" (from nyc-neighborhood-names.json)
+ * @param buildingClassKeys  all building-class keys (from building-class.json)
+ */
+export function aggregateSales(
+  sales: RawSaleProperties[],
+  ntaCodes: string[],
+  buildingClassKeys: string[],
+): BrooklynDisplayData {
+  // createNeighborhoodDataHash
+  const data: Record<string, NtaAccumulator> = {};
+  for (const key of ntaCodes) {
+    data[key] = {
+      residentialSaleTally: createQuarterlyHash<number>(() => 0),
+      residentialPrices: createQuarterlyHash<number[]>(() => []),
+      commercialSaleTally: createQuarterlyHash<number>(() => 0),
+      commercialPrices: createQuarterlyHash<number[]>(() => []),
+      buildingClass: createYearlyBuildingClassHash(buildingClassKeys),
+    };
+  }
+
+  // tallyCounts
+  for (const raw of sales) {
+    const sale = normalizeSale(raw);
+    const bucket = sale.ntacode ? data[sale.ntacode] : undefined;
+    if (!bucket) continue;
+    const dateKey = `${sale.quarter}-${sale.year}`;
+
+    if (sale.residentia > 0 && sale.commercial < 1 && sale.residentia < 10) {
+      if (bucket.residentialSaleTally[dateKey] !== undefined)
+        bucket.residentialSaleTally[dateKey]++;
+      if (sale.pricePerSqFt && bucket.residentialPrices[dateKey]) {
+        bucket.residentialPrices[dateKey].push(Number(sale.pricePerSqFt));
+      }
+    } else if (sale.commercial) {
+      if (bucket.commercialSaleTally[dateKey] !== undefined) bucket.commercialSaleTally[dateKey]++;
+      if (sale.pricePerSqFt && bucket.commercialPrices[dateKey]) {
+        bucket.commercialPrices[dateKey].push(Number(sale.pricePerSqFt));
+      }
+    }
+
+    if (sale.buildingClass.length > 0) {
+      const yearBucket = bucket.buildingClass[String(sale.year)];
+      const bc = sale.buildingClass.substring(0, 2);
+      if (yearBucket && yearBucket[bc] !== undefined) yearBucket[bc]++;
+    }
+  }
+
+  computeBuildingClassPercent(data, ntaCodes);
+  return formatSalesDataForDisplay(data, ntaCodes);
+}
+
+/** Convert per-year building-class counts to percentages (port of computeBuildingClassPercent). */
+function computeBuildingClassPercent(
+  data: Record<string, NtaAccumulator>,
+  ntaCodes: string[],
+): void {
+  for (const key of ntaCodes) {
+    for (const date of Object.keys(data[key].buildingClass)) {
+      const classes = data[key].buildingClass[date];
+      let total = 0;
+      for (const bc of Object.keys(classes)) total += classes[bc];
+      for (const bc of Object.keys(classes)) {
+        if (classes[bc] > 0) {
+          const value = Number(((classes[bc] / total) * 100).toFixed(2));
+          classes[bc] = value > 1 ? value : 0;
+        }
+      }
+    }
+  }
+}
+
+/** Collect every value across all NTAs per quarter-key (port of getSalesTotals). */
+function getSalesTotals(
+  data: Record<string, NtaAccumulator>,
+  ntaCodes: string[],
+): Record<string, number[]> {
+  const totals: Record<string, number[]> = {};
+  for (const ntaID of ntaCodes) {
+    const series = data[ntaID].residentialPrices;
+    for (const itemKey of Object.keys(series)) {
+      (totals[itemKey] ||= []).push(...series[itemKey]);
+    }
+  }
+  return totals;
+}
+
+function formatSalesDataForDisplay(
+  data: Record<string, NtaAccumulator>,
+  ntaCodes: string[],
+): BrooklynDisplayData {
+  const formatted: BrooklynDisplayData = {};
+
+  for (const ntaID of ntaCodes) {
+    const flattened: NeighborhoodDisplayData = {
+      residentialPrices: [],
+      buildingClass: {},
+    };
+
+    for (const key of SALES_DATA_KEYS) {
+      const series = data[ntaID][key];
+      flattened[key] = Object.keys(series).map((itemKey) => {
+        const arr = series[itemKey].slice().sort(ascending);
+        const m = mean(arr);
+        return { date: quarterKeyToEpoch(itemKey), value: m ? Number(m.toFixed(2)) : 0 };
+      });
+
+      if (ntaID === 'ALL') {
+        const totals = getSalesTotals(data, ntaCodes);
+        flattened[`${key}-mean`] = Object.keys(totals).map((totalKey) => ({
+          date: quarterKeyToEpoch(totalKey),
+          value: Number((mean(totals[totalKey]) ?? 0).toFixed(2)),
+        }));
+      }
+
+      if (ntaID === 'BK73') {
+        flattened.williamsburgTrend = Object.keys(series).map((itemKey) => {
+          const arr = series[itemKey].slice().sort(ascending);
+          return {
+            date: quarterKeyToEpoch(itemKey),
+            pct25: Number((quantile(arr, 0.25) ?? 0).toFixed(2)),
+            value: Number((mean(arr) ?? 0).toFixed(2)),
+            pct75: Number((quantile(arr, 0.75) ?? 0).toFixed(2)),
+          };
+        });
+      }
+    }
+
+    flattened.buildingClass = formatBuildingClassData(data[ntaID].buildingClass);
+    formatted[ntaID] = flattened;
+  }
+
+  return formatted;
+}
+
+/** Port of formatBuildingClassData: per valid class, a per-year fractional series. */
+function formatBuildingClassData(
+  buildingClass: Record<string, Record<string, number>>,
+): Record<string, DateValue[]> {
+  const out: Record<string, DateValue[]> = {};
+  const dateKeys = Object.keys(buildingClass);
+  for (const dataKey of VALID_RESIDENTIAL_BUILDING_CLASSES) {
+    out[dataKey] = dateKeys.map((dateKey) => ({
+      date: yearKeyToEpoch(dateKey),
+      value: Number((buildingClass[dateKey][dataKey] / 100).toFixed(4)),
+    }));
+  }
+  return out;
+}

--- a/scripts/etl/brooklyn/build.ts
+++ b/scripts/etl/brooklyn/build.ts
@@ -1,0 +1,48 @@
+/**
+ * Brooklyn display-data build step (tsx-runnable: `npm run data:build:brooklyn`).
+ *
+ * Reads the raw geocoded sales GeoJSON, runs the typed aggregation, and writes
+ * `public/data/brooklyn/brooklyn-sales-display-data.json`.
+ *
+ * NOTE: the raw input (`apps/brooklyn/data/brooklyn-sales.json`) is gitignored
+ * and is NOT present in this tree — see docs/etl.md. This script will report a
+ * clear error until the raw dataset is supplied. The aggregation logic itself
+ * is unit-tested against the committed output's date axis.
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { type RawSaleProperties, aggregateSales } from './aggregate';
+
+const ROOT = process.cwd();
+const RAW_INPUT = join(ROOT, 'apps/brooklyn/data/brooklyn-sales.json');
+const OUT = join(ROOT, 'public/data/brooklyn/brooklyn-sales-display-data.json');
+const NAMES = join(ROOT, 'public/data/brooklyn/nyc-neighborhood-names.json');
+const CLASSES = join(ROOT, 'public/data/brooklyn/building-class.json');
+
+function main(): void {
+  if (!existsSync(RAW_INPUT)) {
+    console.error(
+      `Raw input not found: ${RAW_INPUT}\n` +
+        `It is gitignored and not committed. Supply the geocoded sales GeoJSON ` +
+        `(see docs/etl.md) before running this build.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const geo = JSON.parse(readFileSync(RAW_INPUT, 'utf8')) as {
+    features: { properties: RawSaleProperties }[];
+  };
+  const sales = geo.features.map((f) => f.properties);
+  const ntaCodes = Object.keys(JSON.parse(readFileSync(NAMES, 'utf8')));
+  const buildingClassKeys = Object.keys(JSON.parse(readFileSync(CLASSES, 'utf8')));
+
+  const display = aggregateSales(sales, ntaCodes, buildingClassKeys);
+  writeFileSync(OUT, JSON.stringify(display));
+  console.log(
+    `Wrote ${OUT} (${sales.length} sales -> ${Object.keys(display).length} neighborhoods)`,
+  );
+}
+
+main();

--- a/scripts/etl/brooklyn/geocode.ts
+++ b/scripts/etl/brooklyn/geocode.ts
@@ -1,0 +1,113 @@
+/**
+ * Brooklyn sales geocoding — typed port of `apps/brooklyn/geocode-sales.coffee`.
+ *
+ * Offline step: attaches lat/long to raw sales via the BBL lookups, then emits a
+ * GeoJSON FeatureCollection of the sales that resolved to coordinates. This is
+ * the input to the aggregation step (`aggregate.ts`).
+ *
+ * The lookups (`bbl-to-lat-long.json`, `block-lot-to-bbl.json`) are used ONLY
+ * here — they never ship to the client (see docs/etl.md). Ported for repro
+ * completeness; the raw sales input is gitignored/absent (issue #15).
+ */
+import { formatBBL } from '../lib/bbl';
+
+/** A raw sale row (NYC rolling-sales export; field names vary by vintage). */
+export interface RawSale {
+  x?: number;
+  y?: number;
+  bbl?: string;
+  BLOCK?: number | string;
+  LOT?: number | string;
+  block?: number | string;
+  lot?: number | string;
+  'BUILDING CLASS CATEGORY'?: string;
+  'RESIDENTIAL UNITS'?: number;
+  'COMMERCIAL UNITS'?: number;
+  'LAND SQUARE FEET'?: string | number;
+  'GROSS SQUARE FEET'?: string | number;
+  'YEAR BUILT'?: number;
+  'SALE PRICE'?: string | number;
+  'SALE DATE'?: string | number;
+}
+
+/** [lat, long] keyed by 10-char BBL. */
+export type BblToLatLong = Record<string, [number | null, number | null]>;
+/** BBL keyed by "block-lot". */
+export type BlockLotToBbl = Record<string, string>;
+
+export interface SaleFeature {
+  type: 'Feature';
+  properties: Record<string, unknown>;
+  geometry: { type: 'Point'; coordinates: [number | null, number | null] };
+}
+
+export interface SalesFeatureCollection {
+  type: 'FeatureCollection';
+  crs: { type: 'name'; properties: { name: string } };
+  features: SaleFeature[];
+}
+
+export interface GeocodeResult {
+  collection: SalesFeatureCollection;
+  stats: { total: number; success: number; fail: number; noCoords: number };
+}
+
+/** Geocode raw sales and build the cleaned GeoJSON (port of geocode-sales.coffee). */
+export function geocodeSales(
+  sales: RawSale[],
+  bblToLatLong: BblToLatLong,
+  blockLotToBbl: BlockLotToBbl,
+): GeocodeResult {
+  let success = 0;
+  let fail = 0;
+  let noCoords = 0;
+  let total = 0;
+
+  const geocoded = sales.map((sale) => {
+    total++;
+    if (!sale.x) {
+      noCoords++;
+      if (sale.BLOCK != null) {
+        sale.bbl = blockLotToBbl[`${sale.BLOCK}-${sale.LOT}`];
+      } else if (sale.block != null) {
+        sale.bbl = blockLotToBbl[`${sale.block}-${sale.lot}`];
+      }
+      sale.bbl ||= formatBBL(3, sale.BLOCK ?? '', sale.LOT ?? '');
+      const coords = bblToLatLong[sale.bbl];
+      if (coords) {
+        sale.x = coords[0] ?? undefined;
+        sale.y = coords[1] ?? undefined;
+        success++;
+      } else {
+        fail++;
+      }
+    }
+    return sale;
+  });
+
+  const withCoords = geocoded.filter((s) => Boolean(s.x));
+
+  const collection: SalesFeatureCollection = {
+    type: 'FeatureCollection',
+    crs: { type: 'name', properties: { name: 'urn:ogc:def:crs:OGC:1.3:CRS84' } },
+    features: withCoords.map((sale) => ({
+      type: 'Feature',
+      properties: {
+        buildingClass: String(sale['BUILDING CLASS CATEGORY'] ?? '').trim(),
+        bbl: sale.bbl,
+        block: sale.BLOCK,
+        lot: sale.LOT,
+        residential: sale['RESIDENTIAL UNITS'],
+        commercial: sale['COMMERCIAL UNITS'],
+        landSqFt: sale['LAND SQUARE FEET'],
+        grossSqFt: sale['GROSS SQUARE FEET'],
+        built: sale['YEAR BUILT'],
+        price: sale['SALE PRICE'],
+        date: new Date(sale['SALE DATE'] ?? 0).valueOf(),
+      },
+      geometry: { type: 'Point', coordinates: [sale.y ?? null, sale.x ?? null] },
+    })),
+  };
+
+  return { collection, stats: { total, success, fail, noCoords } };
+}

--- a/scripts/etl/build.ts
+++ b/scripts/etl/build.ts
@@ -1,0 +1,28 @@
+/**
+ * Aggregate ETL runner (tsx-runnable: `npm run data:build`).
+ *
+ * Runs every app's display-data build in turn. Each step is a no-op-with-error
+ * if its gitignored raw input is absent (see docs/etl.md), so this is safe to
+ * run in CI as a smoke check once raws are supplied.
+ *
+ * As the remaining apps (311, chicago, north-carolina) are ported, import and
+ * call their build steps here.
+ */
+import { execFileSync } from 'node:child_process';
+
+const steps = ['scripts/etl/brooklyn/build.ts'];
+
+let failed = false;
+for (const step of steps) {
+  console.log(`\n=== ${step} ===`);
+  try {
+    execFileSync('npx', ['tsx', step], { stdio: 'inherit' });
+  } catch {
+    failed = true;
+  }
+}
+
+if (failed) {
+  console.error('\nOne or more ETL steps failed (often: missing raw input — see docs/etl.md).');
+  process.exitCode = 1;
+}

--- a/scripts/etl/build.ts
+++ b/scripts/etl/build.ts
@@ -10,7 +10,12 @@
  */
 import { execFileSync } from 'node:child_process';
 
-const steps = ['scripts/etl/brooklyn/build.ts'];
+const steps = [
+  'scripts/etl/brooklyn/build.ts',
+  'scripts/etl/311/build.ts',
+  'scripts/etl/chicago/build.ts',
+  'scripts/etl/north-carolina/build.ts',
+];
 
 let failed = false;
 for (const step of steps) {

--- a/scripts/etl/chicago/aggregate.ts
+++ b/scripts/etl/chicago/aggregate.ts
@@ -1,0 +1,173 @@
+/**
+ * Chicago crime aggregation — typed port of
+ * `apps/chicago/script/format-display-data.coffee` (`getCrimesData`).
+ *
+ * Pure function of its inputs. Produces the `chicago-crimes-display-data.json`
+ * shape: per-neighborhood monthly crime rate (per 1,000 residents) + the ALL
+ * (-mean) series, plus a per-crime-type hour-of-day rate series.
+ */
+import { mean } from 'd3';
+
+import { hourEpoch, monthKeyToEpoch } from '../lib/dates';
+
+/** A crime record after the line-level parse in format-data.coffee. */
+export interface CrimeRecord {
+  crimeType: string;
+  nta: string;
+  month: number;
+  year: number;
+  hour: number;
+}
+
+export interface DateValue {
+  date: number;
+  value: number;
+}
+
+export interface NeighborhoodCrimeData {
+  crimeTally: DateValue[];
+  crimeType: Record<string, DateValue[]>;
+  'crimeTally-mean'?: DateValue[];
+}
+
+export type ChicagoDisplayData = Record<string, NeighborhoodCrimeData>;
+
+/** Population row keyed by neighborhood name. */
+type Population = Record<string, { 'TOTAL-2010': number }>;
+
+const MONTHS = Array.from({ length: 12 }, (_, i) => i + 1);
+const YEARS = Array.from({ length: 2014 - 2003 + 1 }, (_, i) => 2003 + i);
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+const CRIMES_DATA_KEYS = ['crimeTally'] as const;
+const VALID_CRIME_TYPES = [
+  'ASS',
+  'NAR',
+  'BAT',
+  'THE',
+  'HOM',
+  'ROB',
+  'BUR',
+  'SEOF',
+  'CRDA',
+  'OTOF',
+  'RIT',
+];
+
+interface CrimeAccumulator {
+  crimeTally: Record<string, number>;
+  crimeType: Record<number, Record<string, number>>;
+}
+
+function monthKeys(): string[] {
+  const keys: string[] = [];
+  for (const year of YEARS) for (const month of MONTHS) keys.push(`${month}-${year}`);
+  return keys;
+}
+
+function formatDecimal(n: number): number {
+  return Number(Number(n).toFixed(2));
+}
+
+/**
+ * @param crimes      parsed crime records
+ * @param crimeTypes  map of crime-name -> code (crime-types.json); we use its codes
+ * @param neighborhoodNames  nta-code -> neighborhood name (neighborhood-names.json)
+ * @param population  population keyed by neighborhood name
+ * @param nowMs       reference date for the (legacy non-deterministic) hour axis
+ */
+export function aggregateCrimes(
+  crimes: CrimeRecord[],
+  crimeTypes: Record<string, string>,
+  neighborhoodNames: Record<string, string>,
+  population: Population,
+  nowMs: number,
+): ChicagoDisplayData {
+  // formatCrimeTypes inverts the map; the legacy code then iterates its keys
+  // (the original names) as the per-hour bucket keys.
+  const typeKeys = Object.keys(crimeTypes).map((name) => crimeTypes[name]);
+
+  const data: Record<string, CrimeAccumulator> = {};
+  for (const key of Object.keys(neighborhoodNames)) {
+    const crimeTally: Record<string, number> = {};
+    for (const k of monthKeys()) crimeTally[k] = 0;
+    const crimeType: Record<number, Record<string, number>> = {};
+    for (const hour of HOURS) {
+      crimeType[hour] = {};
+      for (const t of typeKeys) crimeType[hour][t] = 0;
+    }
+    data[key] = { crimeTally, crimeType };
+  }
+
+  for (const crime of crimes) {
+    const bucket = data[crime.nta];
+    if (!bucket) continue;
+    if (crime.year > 2014 || crime.year < 2003) continue;
+    const dateKey = `${crime.month}-${crime.year}`;
+    if (bucket.crimeTally[dateKey] !== undefined) bucket.crimeTally[dateKey]++;
+    if (crime.crimeType && crime.crimeType.length > 0) {
+      const hourBucket = bucket.crimeType[crime.hour];
+      if (hourBucket && hourBucket[crime.crimeType] !== undefined) hourBucket[crime.crimeType]++;
+    }
+  }
+
+  // Faithful to the legacy `_.reduce`: in the ALL branch it summed the input,
+  // but `_.reduce` over a *scalar* yields 0. So a scalar input (the regular ALL
+  // series and the d3.mean-based -mean series) collapses to 0; only an array
+  // input sums. This reproduces the committed all-zero chicago ALL series.
+  const averageByPopulation = (value: number | number[], nta: string): number => {
+    if (nta === 'ALL') {
+      const pops = Object.keys(neighborhoodNames).map((code) => {
+        const name = neighborhoodNames[code];
+        return population[name]?.['TOTAL-2010'] ?? 0;
+      });
+      const popTotal = pops.reduce((a, b) => a + b, 0);
+      const dataTotal = Array.isArray(value) ? value.reduce((a, b) => a + b, 0) : 0;
+      return formatDecimal(dataTotal / (popTotal / 1000));
+    }
+    const name = neighborhoodNames[nta];
+    const pop = population[name]?.['TOTAL-2010'];
+    if (!pop) return 0;
+    const v = typeof value === 'number' ? value : 0; // non-ALL is always scalar
+    if (v < 1 || pop < 1) return 0;
+    return formatDecimal(v / (pop / 1000));
+  };
+
+  // formatCrimesDataForDisplay
+  const formatted: ChicagoDisplayData = {};
+  for (const ntaID of Object.keys(data)) {
+    const flattened: NeighborhoodCrimeData = { crimeTally: [], crimeType: {} };
+
+    for (const key of CRIMES_DATA_KEYS) {
+      const series = data[ntaID][key];
+      flattened[key] = Object.keys(series).map((dateKey) => ({
+        date: monthKeyToEpoch(dateKey),
+        value: averageByPopulation(series[dateKey], ntaID),
+      }));
+
+      if (ntaID === 'ALL') {
+        // getCrimeTotals collects each NTA's monthly count per key, then the ALL
+        // -mean takes d3.mean of those before averaging by population.
+        const totals: Record<string, number[]> = {};
+        for (const id of Object.keys(data)) {
+          const s = data[id][key];
+          for (const itemKey of Object.keys(s)) (totals[itemKey] ||= []).push(s[itemKey]);
+        }
+        flattened[`${key}-mean`] = Object.keys(totals).map((totalKey) => ({
+          date: monthKeyToEpoch(totalKey),
+          value: averageByPopulation(mean(totals[totalKey]) ?? 0, ntaID),
+        }));
+      }
+    }
+
+    flattened.crimeType = {};
+    for (const type of VALID_CRIME_TYPES) {
+      flattened.crimeType[type] = HOURS.map((hour) => ({
+        date: hourEpoch(hour, nowMs),
+        value: averageByPopulation(data[ntaID].crimeType[hour][type], ntaID),
+      }));
+    }
+    formatted[ntaID] = flattened;
+  }
+
+  return formatted;
+}

--- a/scripts/etl/chicago/build.ts
+++ b/scripts/etl/chicago/build.ts
@@ -1,0 +1,58 @@
+/**
+ * Chicago display-data build (tsx-runnable). Reads the raw crimes CSV, parses
+ * it to crime records, aggregates, and writes the display JSON.
+ *
+ * Raw input (apps/chicago/data/crimes.csv) is gitignored/absent (issue #15) —
+ * exits with a clear error until supplied. CSV parsing mirrors the legacy
+ * line-by-line reader (apps/chicago/format-data.coffee).
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { getInitials } from '../lib/initials';
+import { type CrimeRecord, aggregateCrimes } from './aggregate';
+
+const ROOT = process.cwd();
+const RAW = join(ROOT, 'apps/chicago/data/crimes.csv');
+const D = join(ROOT, 'public/data/chicago');
+const OUT = join(D, 'chicago-crimes-display-data.json');
+
+function parseDate(s: string): { month: number; year: number; hour: number } {
+  // "MM/DD/YYYY hh:mm:SS A"
+  const [datePart, timePart, ampm] = s.split(' ');
+  const [mm, , yyyy] = datePart.split('/').map(Number);
+  let hour = timePart ? Number(timePart.split(':')[0]) : 0;
+  if (ampm === 'PM' && hour < 12) hour += 12;
+  if (ampm === 'AM' && hour === 12) hour = 0;
+  return { month: mm, year: yyyy, hour };
+}
+
+function main(): void {
+  if (!existsSync(RAW)) {
+    console.error(`Raw input not found: ${RAW}\nGitignored/absent — see docs/etl.md (issue #15).`);
+    process.exitCode = 1;
+    return;
+  }
+  const lines = readFileSync(RAW, 'utf8').split('\n');
+  const records: CrimeRecord[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    if (!lines[i]) continue;
+    const cols = lines[i].split(',');
+    const { month, year, hour } = parseDate(cols[2]);
+    records.push({ crimeType: getInitials(cols[5], 2), nta: cols[13], month, year, hour });
+  }
+  const crimeTypes = JSON.parse(readFileSync(join(D, 'crime-types.json'), 'utf8'));
+  const names = JSON.parse(readFileSync(join(D, 'neighborhood-names.json'), 'utf8'));
+  const population = JSON.parse(readFileSync(join(D, 'chicago-population-2000-2010.json'), 'utf8'));
+  const display = aggregateCrimes(
+    records,
+    crimeTypes,
+    names,
+    population,
+    Date.parse('2015-01-01T00:00:00-05:00'),
+  );
+  writeFileSync(OUT, JSON.stringify(display));
+  console.log(`Wrote ${OUT} (${records.length} crimes)`);
+}
+
+main();

--- a/scripts/etl/lib/bbl.ts
+++ b/scripts/etl/lib/bbl.ts
@@ -1,0 +1,20 @@
+/**
+ * BBL (Borough-Block-Lot) helpers — typed port of
+ * `components/numberutils/bbl.coffee`. Used by the brooklyn geocoding step.
+ */
+
+/** Left-pad a number/string with zeros to `targetLength`. */
+export function leftPad(value: number | string, targetLength: number): string {
+  let output = String(value);
+  while (output.length < targetLength) output = '0' + output;
+  return output;
+}
+
+/** Build a 10-char BBL from borough (1 digit), block (5), lot (4). */
+export function formatBBL(
+  borough: number | string,
+  block: number | string,
+  lot: number | string,
+): string {
+  return `${borough}${leftPad(block, 5)}${leftPad(lot, 4)}`;
+}

--- a/scripts/etl/lib/dates.ts
+++ b/scripts/etl/lib/dates.ts
@@ -1,0 +1,93 @@
+/**
+ * Date helpers for the offline ETL.
+ *
+ * The legacy CoffeeScript used Moment, which parses/formats in the host's local
+ * timezone. The committed display data was generated in **America/New_York**
+ * (DST-aware): e.g. quarter-key "1-2003" -> 1041397200000 (Jan 1 2003 00:00 EST,
+ * UTC-5) but "2-2013" -> Apr 1 2013 00:00 EDT (UTC-4). A naive fixed offset is
+ * wrong because DST membership of Apr 1 varies by year (pre-2007 DST started in
+ * April, so Apr 1 2003-2006 was still EST). We therefore convert through the
+ * America/New_York zone via the Intl API (Node ships full ICU) so the output
+ * matches the committed date axis exactly, on any build host.
+ */
+
+const TZ = 'America/New_York';
+
+/** Offset (localWallClock - UTC) in ms for a given instant in the NY zone. */
+function nyOffsetMs(instant: number): number {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: TZ,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  const parts = dtf.formatToParts(new Date(instant));
+  const map: Record<string, string> = {};
+  for (const p of parts) map[p.type] = p.value;
+  // Intl renders hour "24" for midnight in some engines; normalize to 0.
+  const hour = map.hour === '24' ? 0 : Number(map.hour);
+  const asUTC = Date.UTC(
+    Number(map.year),
+    Number(map.month) - 1,
+    Number(map.day),
+    hour,
+    Number(map.minute),
+    Number(map.second),
+  );
+  return asUTC - instant;
+}
+
+/** Epoch ms for a wall-clock date/time interpreted in America/New_York. */
+function nyWallClockToEpoch(year: number, month0: number, day: number, hour = 0): number {
+  const guess = Date.UTC(year, month0, day, hour);
+  // The offset at the guessed instant is correct for Jan/Apr/Jul/Oct 1st — DST
+  // transitions occur mid-March/early-November at 02:00, far from these dates.
+  return guess - nyOffsetMs(guess);
+}
+
+/**
+ * Convert a legacy `"<quarter>-<year>"` key (e.g. "1-2003") to epoch ms at the
+ * start of that quarter (NY local midnight), matching the committed date axis.
+ */
+export function quarterKeyToEpoch(key: string): number {
+  const [quarterStr, yearStr] = key.split('-');
+  const quarter = Number(quarterStr);
+  const year = Number(yearStr);
+  if (!(quarter >= 1 && quarter <= 4) || !Number.isFinite(year)) {
+    throw new Error(`Invalid quarter key: ${key}`);
+  }
+  return nyWallClockToEpoch(year, (quarter - 1) * 3, 1);
+}
+
+/** Convert a legacy `"<year>"` key (e.g. "2003") to epoch ms at NY-local start of year. */
+export function yearKeyToEpoch(key: string | number): number {
+  const year = Number(key);
+  if (!Number.isFinite(year)) throw new Error(`Invalid year key: ${key}`);
+  return nyWallClockToEpoch(year, 0, 1);
+}
+
+/**
+ * Derive quarter (1-4), 0-based month, and year for a sale's epoch-ms date,
+ * mirroring the legacy `Sale.setupDate` (`moment(ms).add(5, 'hours')` read in
+ * NY-local time). Per-sale tz edge effects can't be validated without the
+ * (absent) raw sales; the quarterly aggregation axis is validated separately.
+ */
+export function deriveSaleDateParts(epochMs: number): {
+  quarter: number;
+  month: number;
+  year: number;
+} {
+  const shifted = Math.floor(epochMs) + 5 * 3600 * 1000;
+  const offset = nyOffsetMs(shifted);
+  const local = new Date(shifted + offset);
+  const month = local.getUTCMonth();
+  return {
+    quarter: Math.floor(month / 3) + 1,
+    month,
+    year: local.getUTCFullYear(),
+  };
+}

--- a/scripts/etl/lib/dates.ts
+++ b/scripts/etl/lib/dates.ts
@@ -63,6 +63,34 @@ export function quarterKeyToEpoch(key: string): number {
   return nyWallClockToEpoch(year, (quarter - 1) * 3, 1);
 }
 
+/**
+ * Convert a legacy `"<month>-<year>"` key (e.g. "1-2010") to epoch ms at NY-local
+ * midnight on the 1st of that month (311 / chicago monthly axis).
+ */
+export function monthKeyToEpoch(key: string): number {
+  const [monthStr, yearStr] = key.split('-');
+  const month = Number(monthStr);
+  const year = Number(yearStr);
+  if (!(month >= 1 && month <= 12) || !Number.isFinite(year)) {
+    throw new Error(`Invalid month key: ${key}`);
+  }
+  return nyWallClockToEpoch(year, month - 1, 1);
+}
+
+/**
+ * Epoch ms for "today at <hour>:00:00 NY-local", mirroring the legacy
+ * `moment(new Date()).hours(h).minutes(0).seconds(0)` used for the 311/chicago
+ * hour-of-day axis. This was **non-deterministic** in the legacy build (depends
+ * on the run date) — `nowMs` is injectable so the output is reproducible and
+ * testable. Pass a fixed reference date when regenerating.
+ */
+export function hourEpoch(hour: number, nowMs: number): number {
+  // moment kept the local calendar day of `now`, set H:M:S. Use NY-local Y/M/D.
+  const offset = nyOffsetMs(nowMs);
+  const local = new Date(nowMs + offset);
+  return nyWallClockToEpoch(local.getUTCFullYear(), local.getUTCMonth(), local.getUTCDate(), hour);
+}
+
 /** Convert a legacy `"<year>"` key (e.g. "2003") to epoch ms at NY-local start of year. */
 export function yearKeyToEpoch(key: string | number): number {
   const year = Number(key);

--- a/scripts/etl/lib/initials.ts
+++ b/scripts/etl/lib/initials.ts
@@ -1,0 +1,16 @@
+/**
+ * Typed port of `components/datautil/get-initials.coffee`. Used by the 311 and
+ * chicago ETL to derive a short category code from a complaint/crime name.
+ */
+
+/**
+ * For a multi-word name, concatenate the first `len` chars of each word; for a
+ * single word, take the first `len + 1` chars. Faithful to the legacy behavior.
+ */
+export function getInitials(name: string, len = 2): string {
+  const words = name.split(' ');
+  if (words.length > 1) {
+    return words.map((word) => word.substring(0, len)).join('');
+  }
+  return name.substring(0, len + 1);
+}

--- a/scripts/etl/north-carolina/aggregate.ts
+++ b/scripts/etl/north-carolina/aggregate.ts
@@ -1,0 +1,114 @@
+/**
+ * North Carolina districts aggregation — typed port of
+ * `apps/north-carolina/script/format-display-data.coffee` (`getData`).
+ *
+ * Joins census-block features with a precinct-level voter tally to produce the
+ * flat per-block array in `display-data.json` (district, point, census stats,
+ * democrat/republican vote share).
+ */
+
+/** Census variable code -> output field name (subset the legacy code emits). */
+const CENSUS_KEYS: Record<string, string> = {
+  B01001e1: 'pop',
+  B02001e2: 'white',
+  B02001e3: 'black',
+  B02001e5: 'asian',
+  B09002e1: 'children',
+  B09017e1: '65',
+  B17017e2: 'poverty',
+  B21001e2: 'veteran',
+  B23025e4: 'employed',
+  B23025e5: 'unemployed',
+  B23025e6: 'armed',
+};
+
+interface CensusProperties {
+  district?: string;
+  GEOID?: string;
+  prec_id?: string;
+  /** Census variable codes (e.g. "B01001e1") and any other numeric fields. */
+  [code: string]: number | string | undefined;
+}
+
+export interface CensusFeature {
+  geometry: { coordinates?: [number, number] };
+  properties: CensusProperties;
+}
+
+export interface RawVote {
+  precinct_abbrv: string;
+  party_cd: 'REP' | 'DEM' | 'UNA' | 'LIB' | string;
+  total_voters: number | string;
+}
+
+export interface DistrictBlock {
+  district?: string;
+  point?: [number, number];
+  id?: string;
+  bachelors: number;
+  democrat?: number;
+  republican?: number;
+  [field: string]: number | string | [number, number] | undefined;
+}
+
+interface PrecinctTally {
+  REP: number;
+  DEM: number;
+  UNA: number;
+  LIB: number;
+  total: number;
+}
+
+/** Sum voters per precinct (port of tallyVotesByPrec). Keyed by `precinct_abbrv`. */
+export function tallyVotesByPrecinct(rawVotes: RawVote[]): Record<string, PrecinctTally> {
+  const votes: Record<string, PrecinctTally> = {};
+  for (const vote of rawVotes) {
+    const key = vote.precinct_abbrv;
+    votes[key] ||= { REP: 0, DEM: 0, UNA: 0, LIB: 0, total: 0 };
+    const n = Number(vote.total_voters);
+    if (vote.party_cd in votes[key]) {
+      (votes[key] as unknown as Record<string, number>)[vote.party_cd] += n;
+    }
+    votes[key].total += n;
+  }
+  return votes;
+}
+
+/**
+ * Build the flat per-block array. Features without geometry coordinates yield
+ * `undefined` (faithful to the legacy comprehension); callers can `.filter(Boolean)`.
+ *
+ * NOTE: the legacy code tallies votes by `precinct_abbrv` but looks them up by
+ * the feature's `prec_id`; preserved as-is. A block whose `prec_id` has no tally
+ * gets no democrat/republican fields.
+ */
+export function getDistrictData(
+  features: CensusFeature[],
+  rawVotes: RawVote[],
+): (DistrictBlock | undefined)[] {
+  const votes = tallyVotesByPrecinct(rawVotes);
+
+  return features.map((feature) => {
+    if (!feature.geometry.coordinates) return undefined;
+    const p = feature.properties;
+    const data: DistrictBlock = {
+      district: p.district,
+      point: feature.geometry.coordinates,
+      id: p.GEOID,
+      bachelors: 0,
+    };
+
+    for (const key of Object.keys(CENSUS_KEYS)) {
+      data[CENSUS_KEYS[key]] = p[key] as number;
+    }
+    data.bachelors = Number(p['B15002e15'] ?? 0) + Number(p['B15002e32'] ?? 0);
+
+    const precID = p.prec_id;
+    const tally = precID ? votes[precID] : undefined;
+    if (tally) {
+      data.democrat = (tally.DEM / tally.total) * 100;
+      data.republican = (tally.REP / tally.total) * 100;
+    }
+    return data;
+  });
+}

--- a/scripts/etl/north-carolina/build.ts
+++ b/scripts/etl/north-carolina/build.ts
@@ -1,0 +1,34 @@
+/**
+ * North Carolina display-data build (tsx-runnable). Joins census-block features
+ * with the voter tally and writes the flat per-block display JSON.
+ *
+ * Raw inputs (census-block-by-district.json + vote-tally.json) are
+ * gitignored/absent (issue #15) — exits with a clear error until supplied.
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { type CensusFeature, type RawVote, getDistrictData } from './aggregate';
+
+const ROOT = process.cwd();
+const D = join(ROOT, 'apps/north-carolina/data');
+const CENSUS = join(D, 'census-block-by-district.json');
+const VOTES = join(D, 'vote-tally.json');
+const OUT = join(ROOT, 'public/data/north-carolina/display-data.json');
+
+function main(): void {
+  if (!existsSync(CENSUS) || !existsSync(VOTES)) {
+    console.error(
+      `Raw inputs not found under ${D}\nGitignored/absent — see docs/etl.md (issue #15).`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  const features = JSON.parse(readFileSync(CENSUS, 'utf8')).features as CensusFeature[];
+  const rawVotes = JSON.parse(readFileSync(VOTES, 'utf8')) as RawVote[];
+  const display = getDistrictData(features, rawVotes);
+  writeFileSync(OUT, JSON.stringify(display));
+  console.log(`Wrote ${OUT} (${display.length} blocks)`);
+}
+
+main();


### PR DESCRIPTION
Ports the legacy CoffeeScript offline ETL (`apps/*/format-data.coffee`, `apps/*/script/format-display-data.coffee`, `apps/brooklyn/geocode-sales.coffee`) to typed, unit-tested, tsx-runnable TypeScript under `scripts/etl/` (MIGRATION.md §2.3). These run at build time, never in the client.

## Two premise corrections (confirmed with god)
1. **Raw inputs are absent.** Every pipeline's gitignored raw dataset (brooklyn sales, 311 export, chicago CSV, NC census+votes) is not in the tree, so display JSON can't be regenerated byte-for-byte here. The committed `public/data/**` is the **canonical source of truth**; the ported TS reproduces the logic and runs when a raw is supplied. Sourcing raws for a one-time real regen is tracked in **#15**.
2. **The 12 MB `bbl-to-lat-long.json` already never ships to the client** — it's used only in the offline geocode step. The brooklyn map is an NTA choropleth + aggregate charts (no per-sale points), so there was no bundle-bloat to fix. (Final brooklyn output shape still pending Pam's confirmation on whether any future view needs per-sale points.)

## What's here
- `scripts/etl/lib/` — `dates.ts` (quarter/month/year key → epoch via **America/New_York**, DST-aware through `Intl`; a fixed offset is wrong because Apr 1's DST membership varies by year), `bbl.ts`, `initials.ts`.
- `scripts/etl/brooklyn/` — `aggregate.ts` (typed `getSalesData`: per-NTA quarterly price means, building-class %, `ALL` -mean + `BK73` williamsburgTrend) and `geocode.ts`.
- `scripts/etl/{311,chicago,north-carolina}/aggregate.ts` — monthly rate + hour-of-day series / per-block census+vote join.
- Per-app `build.ts` runners + `npm run data:build[:app]` (clean error per step on missing raw input).
- `docs/etl.md` — pipeline map, the canonical-JSON / missing-raw reality (#15), date-handling note.

## Faithful legacy quirks (verified against committed data)
- **Non-deterministic hour axis** (`moment(new Date())`) → now an injectable `nowMs`.
- **`_.reduce` over a scalar yields 0** → chicago's `ALL` series are all-zero while 311's `-mean` sums an array. Matches committed output.
- Brooklyn date axis matches the committed `brooklyn-sales-display-data.json` exactly.

## Verified locally (all green)
`lint` · `format:check` · `typecheck` · `check` (astro) · `test` (35 tests) · `build` · `knip` (exit 0) · `data:build` (errors cleanly per step on absent raws)

## Not in scope
Brooklyn final output-shape/wiring (waits on Pam's SvgMap consuming contract); real byte-diff regen (needs raws — #15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)