### PR TITLE
ci: bump actions/setup-node 4 → 6 (from Dependabot #12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'


### PR DESCRIPTION
Applies the `actions/setup-node@v4 → @v6` bump from Dependabot **#12**, which conflicted with `main` after **#11** (`actions/checkout@v6`) merged — both edit `.github/workflows/ci.yml`. CI on #12 had already validated v6.

Branch protection blocks direct pushes to `main`, so this small bump goes through a PR. #12 has been closed in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)