### PR TITLE
infra hygiene: repo .editorconfig + package-lock sync

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/package-lock.json
+++ b/package-lock.json
@@ -11341,6 +11341,22 @@
         }
       }
     },
+    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/vitefu": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",


### PR DESCRIPTION
Two small CI-hygiene fixes for the migration foundation.

### 1. Repo `.editorconfig` (local prettier == CI)
Agent worktrees live under `$HOME`, where a stray `~/.editorconfig` (`root=true, indent_style=tab`, untracked, from 2018) made **local** prettier emit tabs while **CI** (no editorconfig) used prettier's space default — so `npm run format` silently diverged from `format:check` and reformatted untouched scaffold files (root cause of Pam's #16 CI failures). A repo-level `root=true` `.editorconfig` (spaces, size 2, utf-8, lf, final newline, trim trailing) shadows the stray one so every agent matches CI.
Verified: `npm run format:check` and `prettier --list-different --no-editorconfig …` agree (both clean) from a `$HOME` worktree.

### 2. `package-lock.json` sync
Dependabot group PR #18 landed a lockfile missing the nested `vite-tsconfig-paths/node_modules/typescript@5.9.3` entry. CI's npm tolerated it, but `npm ci` fails locally with `Missing: typescript@5.9.3 from lock file`. `npm install` adds only that one entry; this restores package.json/lock sync so `npm ci` is reliably green everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)