### PR TITLE
P2.2: port 5 pages to Astro+React on Pam's typed component surface

### DIFF
--- a/__tests__/e2e/smoke.spec.ts
+++ b/__tests__/e2e/smoke.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from '@playwright/test';
+
+// Collect console errors during a page visit
+function collectErrors(page: import('@playwright/test').Page): () => string[] {
+  const errors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error' && /Error|error/.test(msg.text())) {
+      errors.push(msg.text());
+    }
+  });
+  page.on('pageerror', (err) => {
+    errors.push(err.message);
+  });
+  return () => errors;
+}
+
+test.describe('Home page (/)', () => {
+  test('loads and contains navigation links and header', async ({ page }) => {
+    const getErrors = collectErrors(page);
+    const response = await page.goto('/', { waitUntil: 'networkidle' });
+
+    expect(response?.status()).toBe(200);
+    await expect(page.getByText('VISLET')).toBeVisible();
+    await expect(page.getByRole('link', { name: /Brooklyn Property Sales/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /NYC 311/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Chicago Crime/i })).toBeVisible();
+
+    expect(getErrors()).toHaveLength(0);
+  });
+});
+
+test.describe('Brooklyn page (/brooklyn)', () => {
+  test('loads and renders an SVG', async ({ page }) => {
+    const getErrors = collectErrors(page);
+    await page.goto('/brooklyn', { waitUntil: 'networkidle' });
+
+    await expect(page.locator('svg').first()).toBeVisible();
+    expect(getErrors()).toHaveLength(0);
+  });
+
+  test('?area=BK60 loads without error', async ({ page }) => {
+    const getErrors = collectErrors(page);
+    await page.goto('/brooklyn?area=BK60', { waitUntil: 'networkidle' });
+
+    await expect(page.locator('svg').first()).toBeVisible();
+    expect(getErrors()).toHaveLength(0);
+  });
+
+  test('?date=1041397200000 loads without error', async ({ page }) => {
+    const getErrors = collectErrors(page);
+    await page.goto('/brooklyn?date=1041397200000', { waitUntil: 'networkidle' });
+
+    await expect(page.locator('svg').first()).toBeVisible();
+    expect(getErrors()).toHaveLength(0);
+  });
+});
+
+test.describe('311 page (/311)', () => {
+  test('loads and renders an SVG', async ({ page }) => {
+    const getErrors = collectErrors(page);
+    await page.goto('/311', { waitUntil: 'networkidle' });
+
+    await expect(page.locator('svg').first()).toBeVisible();
+    expect(getErrors()).toHaveLength(0);
+  });
+
+  test('?area=BK50 loads without error', async ({ page }) => {
+    const getErrors = collectErrors(page);
+    await page.goto('/311?area=BK50', { waitUntil: 'networkidle' });
+
+    await expect(page.locator('svg').first()).toBeVisible();
+    expect(getErrors()).toHaveLength(0);
+  });
+
+  test('?type=HEAT loads without error', async ({ page }) => {
+    const getErrors = collectErrors(page);
+    await page.goto('/311?type=HEAT', { waitUntil: 'networkidle' });
+
+    await expect(page.locator('svg').first()).toBeVisible();
+    expect(getErrors()).toHaveLength(0);
+  });
+});
+
+test.describe('Chicago page (/chicago)', () => {
+  test('loads and renders an SVG', async ({ page }) => {
+    const getErrors = collectErrors(page);
+    await page.goto('/chicago', { waitUntil: 'networkidle' });
+
+    await expect(page.locator('svg').first()).toBeVisible();
+    expect(getErrors()).toHaveLength(0);
+  });
+
+  test('?area=2 loads without error', async ({ page }) => {
+    const getErrors = collectErrors(page);
+    await page.goto('/chicago?area=2', { waitUntil: 'networkidle' });
+
+    await expect(page.locator('svg').first()).toBeVisible();
+    expect(getErrors()).toHaveLength(0);
+  });
+
+  test('?type=ASS loads without error', async ({ page }) => {
+    const getErrors = collectErrors(page);
+    await page.goto('/chicago?type=ASS', { waitUntil: 'networkidle' });
+
+    await expect(page.locator('svg').first()).toBeVisible();
+    expect(getErrors()).toHaveLength(0);
+  });
+});
+
+test.describe('North Carolina page (/north-carolina)', () => {
+  test('loads and renders an SVG', async ({ page }) => {
+    const getErrors = collectErrors(page);
+    await page.goto('/north-carolina', { waitUntil: 'networkidle' });
+
+    await expect(page.locator('svg').first()).toBeVisible();
+    expect(getErrors()).toHaveLength(0);
+  });
+
+  test('?area=official-2012 loads without error', async ({ page }) => {
+    const getErrors = collectErrors(page);
+    await page.goto('/north-carolina?area=official-2012', { waitUntil: 'networkidle' });
+
+    await expect(page.locator('svg').first()).toBeVisible();
+    expect(getErrors()).toHaveLength(0);
+  });
+
+  test('?area=splitline loads without error', async ({ page }) => {
+    const getErrors = collectErrors(page);
+    await page.goto('/north-carolina?area=splitline', { waitUntil: 'networkidle' });
+
+    await expect(page.locator('svg').first()).toBeVisible();
+    expect(getErrors()).toHaveLength(0);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "0.9.9",
+        "@playwright/test": "1.60.0",
         "@tailwindcss/postcss": "4.3.0",
         "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "6.9.1",
@@ -2705,6 +2706,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -9068,6 +9085,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint . --ext .ts,.tsx,.astro --max-warnings=0",
     "lint:fix": "eslint . --ext .ts,.tsx,.astro --fix",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest --watch",
     "typecheck": "tsc --noEmit",
@@ -38,6 +39,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "0.9.9",
+    "@playwright/test": "1.60.0",
     "@tailwindcss/postcss": "4.3.0",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './__tests__/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:4321',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:4321',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/src/components/pages/Brooklyn.tsx
+++ b/src/components/pages/Brooklyn.tsx
@@ -1,0 +1,256 @@
+/**
+ * Brooklyn — interactive page component.
+ *
+ * Ports apps/brooklyn/client/index.coffee to a typed React 19 island.
+ * Fetches data lazily from /public/data/brooklyn/ on mount; no data bundled.
+ * URL deep-link wiring via @/lib/url-state (area, date params).
+ */
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { AreaChart } from '@/components/AreaChart';
+import { DateSlider } from '@/components/DateSlider';
+import { LineGraph } from '@/components/LineGraph';
+import { SvgMap } from '@/components/SvgMap';
+import type { AreaData } from '@/lib/area-chart';
+import { formatName } from '@/lib/format';
+import type { LineGraphData } from '@/lib/line-chart';
+import { parseGraphState, serializeGraphState } from '@/lib/url-state';
+import type { BrooklynData, ColorDatum, DataPoint } from '@/types';
+
+const DEFAULT_SELECTED_ID = 'BK60';
+const MAP_WIDTH = 500;
+const MAP_HEIGHT = 400;
+const CHART_WIDTH = 490;
+const CHART_HEIGHT = 230;
+const SLIDER_WIDTH = 502;
+const IGNORED_IDS = ['99', '98'];
+
+export function Brooklyn() {
+  const [salesData, setSalesData] = useState<BrooklynData | null>(null);
+  const [topology, setTopology] = useState<unknown>(null);
+  const [neighborhoodNames, setNeighborhoodNames] = useState<Record<string, string>>({});
+  const [buildingClasses, setBuildingClasses] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+
+  const [selectedId, setSelectedId] = useState(DEFAULT_SELECTED_ID);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [selectedDate, setSelectedDate] = useState<number>(0);
+
+  useEffect(() => {
+    Promise.all([
+      fetch('/data/brooklyn/brooklyn-sales-display-data.json').then((r) => r.json()),
+      fetch('/data/brooklyn/brooklyn.json').then((r) => r.json()),
+      fetch('/data/brooklyn/nyc-neighborhood-names.json').then((r) => r.json()),
+      fetch('/data/brooklyn/building-class.json').then((r) => r.json()),
+    ]).then(([sales, topo, names, classes]) => {
+      const typedSales = sales as BrooklynData;
+      setSalesData(typedSales);
+      setTopology(topo);
+      setNeighborhoodNames(names as Record<string, string>);
+      setBuildingClasses(classes as Record<string, string>);
+
+      const prices = typedSales['ALL']?.residentialPrices ?? [];
+      const lastDate = prices[prices.length - 1]?.date ?? 0;
+
+      const graphState = parseGraphState(window.location.search);
+      if (graphState.kind === 'area') {
+        setSelectedId(graphState.area);
+        if (graphState.hover) setHoveredId(graphState.hover);
+        setSelectedDate(lastDate);
+      } else if (graphState.kind === 'date') {
+        setSelectedDate(graphState.date);
+      } else {
+        setSelectedDate(lastDate);
+      }
+
+      setLoading(false);
+    });
+  }, []);
+
+  // URL sync
+  useEffect(() => {
+    if (!salesData) return;
+    const qs = serializeGraphState({
+      kind: 'area',
+      area: selectedId,
+      hover: hoveredId ?? undefined,
+    });
+    window.history.replaceState(null, '', `?${qs}`);
+  }, [selectedId, hoveredId, salesData]);
+
+  useEffect(() => {
+    if (!salesData || selectedDate === 0) return;
+    const current = parseGraphState(window.location.search);
+    if (current.kind !== 'area') {
+      window.history.replaceState(
+        null,
+        '',
+        `?${serializeGraphState({ kind: 'date', date: selectedDate })}`,
+      );
+    }
+  }, [selectedDate, salesData]);
+
+  const dates = useMemo(
+    () => salesData?.['ALL']?.residentialPrices?.map((d) => d.date) ?? [],
+    [salesData],
+  );
+
+  const colorData: ColorDatum[] = useMemo(() => {
+    if (!salesData) return [];
+    const result: ColorDatum[] = [];
+    for (const [id, data] of Object.entries(salesData)) {
+      if (id === 'ALL') continue;
+      if (IGNORED_IDS.some((ignored) => id.includes(ignored))) continue;
+      const prices = data.residentialPrices ?? [];
+      let best: number | null = null;
+      for (const pt of prices) {
+        if (pt.date <= selectedDate) best = pt.value;
+        else break;
+      }
+      if (best !== null) result.push({ id, value: best });
+    }
+    return result;
+  }, [salesData, selectedDate]);
+
+  const mapColorMax = useMemo(() => {
+    if (!salesData) return 1000;
+    let max = 0;
+    for (const [id, data] of Object.entries(salesData)) {
+      if (id === 'ALL') continue;
+      for (const pt of data.residentialPrices ?? []) {
+        if (pt.value > max) max = pt.value;
+      }
+    }
+    return max;
+  }, [salesData]);
+
+  const lineData: LineGraphData = useMemo(() => {
+    if (!salesData) return {};
+    const result: Record<string, Record<string, DataPoint[]>> = {
+      ALL: { 'residentialPrices-mean': salesData['ALL']?.['residentialPrices-mean'] ?? [] },
+    };
+    result[selectedId] = { residentialPrices: salesData[selectedId]?.residentialPrices ?? [] };
+    return result;
+  }, [salesData, selectedId]);
+
+  const areaData = useMemo(
+    () =>
+      (salesData?.[selectedId]?.buildingClass ??
+        salesData?.['ALL']?.buildingClass ??
+        {}) as unknown as AreaData,
+    [salesData, selectedId],
+  );
+
+  const formatHoverText = useCallback(
+    (id: string) => {
+      const name = formatName(neighborhoodNames[id]) ?? id;
+      const datum = colorData.find((d) => d.id === id);
+      return datum ? `${name} — $${Math.round(datum.value)}/sqft` : name;
+    },
+    [neighborhoodNames, colorData],
+  );
+
+  const selectedName = formatName(neighborhoodNames[selectedId]) ?? selectedId;
+
+  if (loading || !topology || !salesData) {
+    return (
+      <div id="brooklyn" className="map-app">
+        <p style={{ padding: '2rem' }}>Loading Brooklyn data…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div id="brooklyn" className="map-app">
+      <header>
+        <div className="heading">Brooklyn Residential Sales 2003–2014</div>
+        <div className="border" />
+      </header>
+
+      <div className="map-svg-container">
+        <SvgMap
+          topology={topology as Parameters<typeof SvgMap>[0]['topology']}
+          objectKey="neighborhoods"
+          width={MAP_WIDTH}
+          height={MAP_HEIGHT}
+          scale={1.07}
+          translateX={37}
+          translateY={0}
+          ignoredIds={IGNORED_IDS}
+          colorData={colorData}
+          colorMin={0}
+          colorMax={mapColorMax}
+          selectedId={selectedId}
+          hoveredId={hoveredId ?? undefined}
+          onSelect={(id) => setSelectedId(id ?? DEFAULT_SELECTED_ID)}
+          onHover={setHoveredId}
+          title="Avg Price per SQFT"
+          formatHoverText={formatHoverText}
+        />
+
+        <DateSlider
+          dates={dates}
+          value={selectedDate}
+          onChange={setSelectedDate}
+          width={SLIDER_WIDTH}
+        />
+      </div>
+
+      <div className="svg-graphs">
+        <p className="graph-help-text">
+          Click on a neighborhood like &ldquo;Williamsburg&rdquo; to see how the housing market has
+          changed since 2003.
+        </p>
+        <div className="svg-graphs-content">
+          <div className="graph-heading-container">
+            <div className="selected-neighborhood-name">
+              <span className="circle-key blue" />
+              <span className="graph-heading">{selectedName}</span>
+            </div>
+            <div className="avg-neighborhood-name">
+              <span className="circle-key gray" />
+              <span className="graph-heading">Borough Average</span>
+            </div>
+          </div>
+
+          <LineGraph
+            data={lineData}
+            keys={['residentialPrices', 'residentialPrices-mean']}
+            startingDataset={selectedId}
+            width={CHART_WIDTH}
+            height={CHART_HEIGHT}
+            label="Avg Price per Sqft"
+            yAxisFormat={(v) => `$${v}`}
+            showTooltips
+          />
+
+          <AreaChart
+            data={areaData}
+            width={CHART_WIDTH}
+            height={CHART_HEIGHT}
+            label="Building Class as % of sales"
+            keyLabel={(abbrev) => buildingClasses[abbrev] ?? abbrev}
+            showTooltips
+          />
+        </div>
+      </div>
+
+      <div className="markdown-text">
+        <time dateTime="2014-01-12">January 12, 2015</time>
+        <h1>How Residential Property Sales can help us better understand changes in Brooklyn</h1>
+        <p>
+          Brooklyn has seen dramatic changes in its housing market over the last decade. This
+          visualization explores 322,056 residential property sales from 2003 to 2014, charting
+          shifts in price per square foot across all neighborhoods.
+        </p>
+        <p>
+          Click any neighborhood on the map to see its price history compared to the borough
+          average. The building-class chart below shows the mix of property types as a share of
+          total sales.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pages/Chicago.tsx
+++ b/src/components/pages/Chicago.tsx
@@ -1,0 +1,378 @@
+'use client';
+/**
+ * Chicago Crime page — React island for the Astro page at /chicago.
+ *
+ * Ports apps/chicago/client/index.coffee + select/slider/svg-map wiring.
+ * D3 owns math (scales, path, color quantile); React owns every DOM node.
+ * URL deep-link contract: ?area=<id> ?hover=<id> ?type=<abbrev> ?date=<epochMs>
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { AreaChart } from '@/components/AreaChart';
+import { DateSlider } from '@/components/DateSlider';
+import { LineGraph } from '@/components/LineGraph';
+import { Select } from '@/components/Select';
+import { SvgMap } from '@/components/SvgMap';
+import type { AreaData } from '@/lib/area-chart';
+import type { LineGraphData } from '@/lib/line-chart';
+import { parseGraphState, serializeGraphState } from '@/lib/url-state';
+import type { ChicagoData, ColorDatum } from '@/types';
+
+// ─── constants ───────────────────────────────────────────────────────────────
+
+const DEFAULT_SELECTED_ID = '68';
+const MAP_WIDTH = 500;
+const MAP_HEIGHT = 400;
+const GRAPH_WIDTH = 450;
+const GRAPH_HEIGHT = 120;
+const CHICAGO_ROTATE: [number, number] = [74 + 800 / 60, -38 - 50 / 60]; // [87.333, -39.833]
+const IGNORED_IDS = ['33', '20'];
+
+// ─── types ───────────────────────────────────────────────────────────────────
+
+type Topology = Record<string, unknown>;
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+/** Find the value in a DataPoint[] closest to the given epoch ms. */
+function valueAtDate(points: { date: number; value: number }[], targetDate: number): number {
+  if (!points.length) return 0;
+  let closest = points[0]!;
+  let minDiff = Math.abs(closest.date - targetDate);
+  for (const p of points) {
+    const diff = Math.abs(p.date - targetDate);
+    if (diff < minDiff) {
+      minDiff = diff;
+      closest = p;
+    }
+  }
+  return closest.value;
+}
+
+/**
+ * Build ColorDatum[] for the choropleth. When selectedType === 'ALL', value is
+ * the crime tally at selectedDate. When a specific crime type is selected, value
+ * is the sum of that type's series for the neighborhood.
+ */
+function buildColorData(
+  crimeData: ChicagoData,
+  selectedType: string,
+  selectedDate: number,
+  ignoredIds: string[],
+): ColorDatum[] {
+  return Object.entries(crimeData)
+    .filter(([id]) => id !== 'ALL' && !ignoredIds.includes(id))
+    .map(([id, d]) => {
+      let value: number;
+      if (selectedType === 'ALL') {
+        value = valueAtDate(d.crimeTally, selectedDate);
+      } else {
+        const series = d.crimeType[selectedType];
+        if (!series) {
+          value = 0;
+        } else {
+          value = (series as { date: number; value: number }[]).reduce(
+            (sum, p) => sum + p.value,
+            0,
+          );
+        }
+      }
+      return { id, value };
+    });
+}
+
+/** Build LineGraphData for selected + city-average lines. */
+function buildLineData(
+  crimeData: ChicagoData,
+  selectedId: string,
+  hoveredId: string | null,
+): LineGraphData {
+  const allData = crimeData['ALL'];
+  const result: LineGraphData = {
+    ALL: { 'crimeTally-mean': allData?.['crimeTally-mean'] ?? [] },
+    [selectedId]: { crimeTally: crimeData[selectedId]?.crimeTally ?? [] },
+  };
+  if (hoveredId && hoveredId !== selectedId) {
+    result[hoveredId] = { crimeTally: crimeData[hoveredId]?.crimeTally ?? [] };
+  }
+  return result;
+}
+
+/** Extract sorted unique dates from the ALL crimeTally series. */
+function extractDates(crimeData: ChicagoData): number[] {
+  return (crimeData['ALL']?.crimeTally ?? []).map((p) => p.date).sort((a, b) => a - b);
+}
+
+/**
+ * Invert crime-types.json { full_name → abbrev } to { abbrev → full_name }.
+ * Only include abbrevs that appear in the ALL crimeType data.
+ */
+function buildCrimeTypeOptions(
+  crimeTypesRaw: Record<string, string>,
+  crimeData: ChicagoData,
+): Record<string, string> {
+  const available = new Set(Object.keys(crimeData['ALL']?.crimeType ?? {}));
+  const inverted: Record<string, string> = {};
+  for (const [fullName, abbrev] of Object.entries(crimeTypesRaw)) {
+    if (available.has(abbrev)) {
+      inverted[abbrev] = fullName;
+    }
+  }
+  return inverted;
+}
+
+// ─── component ───────────────────────────────────────────────────────────────
+
+export function Chicago() {
+  const [topology, setTopology] = useState<Topology | null>(null);
+  const [crimeData, setCrimeData] = useState<ChicagoData | null>(null);
+  const [crimeTypeOptions, setCrimeTypeOptions] = useState<Record<string, string>>({});
+  const [neighborhoodNames, setNeighborhoodNames] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+
+  const [selectedId, setSelectedId] = useState<string | null>(DEFAULT_SELECTED_ID);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [selectedType, setSelectedType] = useState<string>('ALL');
+  const [selectedDate, setSelectedDate] = useState<number>(0);
+
+  // ── fetch all data on mount ──────────────────────────────────────────────
+  useEffect(() => {
+    async function fetchAll() {
+      const [topoRes, crimeRes, crimeTypesRes, namesRes] = await Promise.all([
+        fetch('/data/chicago/neighborhoods.json'),
+        fetch('/data/chicago/chicago-crimes-display-data.json'),
+        fetch('/data/chicago/crime-types.json'),
+        fetch('/data/chicago/neighborhood-names.json'),
+      ]);
+
+      const [topo, crime, crimeTypes, names] = await Promise.all([
+        topoRes.json() as Promise<Topology>,
+        crimeRes.json() as Promise<ChicagoData>,
+        crimeTypesRes.json() as Promise<Record<string, string>>,
+        namesRes.json() as Promise<Record<string, string>>,
+      ]);
+
+      setTopology(topo);
+      setCrimeData(crime);
+      setCrimeTypeOptions(buildCrimeTypeOptions(crimeTypes, crime));
+      setNeighborhoodNames(names);
+
+      // default selectedDate = last date in ALL crimeTally
+      const dates = (crime['ALL']?.crimeTally ?? []).map((p) => p.date).sort((a, b) => a - b);
+      const lastDate = dates[dates.length - 1] ?? 0;
+      setSelectedDate(lastDate);
+
+      setLoading(false);
+    }
+    void fetchAll();
+  }, []);
+
+  // ── parse URL on mount ───────────────────────────────────────────────────
+  useEffect(() => {
+    const state = parseGraphState(window.location.search);
+    if (state.kind === 'area') {
+      setSelectedId(state.area);
+      if (state.hover) setHoveredId(state.hover);
+    } else if (state.kind === 'type') {
+      setSelectedType(state.type);
+      setSelectedId(null);
+    } else if (state.kind === 'date') {
+      setSelectedDate(state.date);
+      setSelectedId(null);
+    }
+    // overview: keep defaults
+  }, []);
+
+  // ── sync URL on state changes ────────────────────────────────────────────
+  useEffect(() => {
+    if (loading) return;
+    let qs: string;
+    if (selectedId) {
+      const gs = hoveredId
+        ? { kind: 'area' as const, area: selectedId, hover: hoveredId }
+        : { kind: 'area' as const, area: selectedId };
+      qs = serializeGraphState(gs);
+    } else if (selectedType !== 'ALL') {
+      qs = serializeGraphState({ kind: 'type', type: selectedType });
+    } else if (selectedDate) {
+      qs = serializeGraphState({ kind: 'date', date: selectedDate });
+    } else {
+      qs = serializeGraphState({ kind: 'overview' });
+    }
+    const url = qs ? `?${qs}` : window.location.pathname;
+    window.history.replaceState(null, '', url);
+  }, [selectedId, hoveredId, selectedType, selectedDate, loading]);
+
+  // ── derived data ─────────────────────────────────────────────────────────
+
+  const sliderDates = useMemo(() => (crimeData ? extractDates(crimeData) : []), [crimeData]);
+
+  const colorData = useMemo<ColorDatum[]>(() => {
+    if (!crimeData) return [];
+    return buildColorData(crimeData, selectedType, selectedDate, IGNORED_IDS);
+  }, [crimeData, selectedType, selectedDate]);
+
+  const lineData = useMemo<LineGraphData | null>(() => {
+    if (!crimeData || !selectedId) return null;
+    return buildLineData(crimeData, selectedId, hoveredId);
+  }, [crimeData, selectedId, hoveredId]);
+
+  const areaData = useMemo<AreaData | null>(() => {
+    if (!crimeData || !selectedId) return null;
+    const crimeType = crimeData[selectedId]?.crimeType;
+    if (!crimeType) return null;
+    // crimeType = { abbrev → DataPoint[] } (array, not object map)
+    // AreaData = Record<series_name, Record<time_key, AreaInputPoint>>
+    // Convert each abbrev's array to a Record<string, AreaInputPoint>
+    const result: AreaData = {};
+    for (const [abbrev, points] of Object.entries(crimeType)) {
+      const pointMap: Record<string, { date: number; value: number }> = {};
+      for (let i = 0; i < (points as { date: number; value: number }[]).length; i++) {
+        pointMap[String(i)] = (points as { date: number; value: number }[])[i]!;
+      }
+      result[abbrev] = pointMap;
+    }
+    return result;
+  }, [crimeData, selectedId]);
+
+  // ── event handlers ───────────────────────────────────────────────────────
+
+  const handleSelect = useCallback((id: string | null) => {
+    setSelectedId(id);
+    if (!id) setHoveredId(null);
+  }, []);
+
+  const handleHover = useCallback((id: string | null) => {
+    setHoveredId(id);
+  }, []);
+
+  const handleTypeChange = useCallback((type: string) => {
+    setSelectedType(type);
+  }, []);
+
+  const handleDateChange = useCallback((date: number) => {
+    setSelectedDate(date);
+  }, []);
+
+  // ── formatters ───────────────────────────────────────────────────────────
+
+  const formatHoverText = useCallback(
+    (id: string) => neighborhoodNames[id] ?? id,
+    [neighborhoodNames],
+  );
+
+  const lineKeyLabel = useCallback(
+    (idOrName: string) => {
+      if (idOrName === 'Borough Average') return 'City Average';
+      return neighborhoodNames[idOrName] ?? idOrName;
+    },
+    [neighborhoodNames],
+  );
+
+  const areaKeyLabel = useCallback(
+    (name: string) => crimeTypeOptions[name] ?? name,
+    [crimeTypeOptions],
+  );
+
+  // ── render ───────────────────────────────────────────────────────────────
+
+  const activeNeighborhoodName = selectedId ? (neighborhoodNames[selectedId] ?? selectedId) : null;
+
+  if (loading || !topology || !crimeData) {
+    return <div className="map-app">Loading...</div>;
+  }
+
+  return (
+    <div className="map-app">
+      <header className="map-header">
+        <h1 className="map-title">Chicago Crime 2003–2014</h1>
+        <p className="map-description">
+          5,712,201 crimes shown across Chicago neighborhoods from 2003 to 2014.
+        </p>
+        <div className="map-controls">
+          <Select
+            id="crime-type-select"
+            options={crimeTypeOptions}
+            value={selectedType}
+            onChange={handleTypeChange}
+            includeAll
+          />
+        </div>
+      </header>
+
+      <div className="map-svg-container">
+        <SvgMap
+          topology={topology as unknown as Parameters<typeof SvgMap>[0]['topology']}
+          objectKey="neighborhoods"
+          width={MAP_WIDTH}
+          height={MAP_HEIGHT}
+          rotate={CHICAGO_ROTATE}
+          scale={0.93}
+          translateX={3}
+          translateY={0}
+          ignoredIds={IGNORED_IDS}
+          colorData={colorData}
+          colorMin={0}
+          colorMax={40}
+          selectedId={selectedId}
+          hoveredId={hoveredId}
+          onSelect={handleSelect}
+          onHover={handleHover}
+          title="Crime Rate per 1,000 Residents"
+          formatHoverText={formatHoverText}
+          reverseColorKey
+          zoomOnClick
+        />
+      </div>
+
+      {selectedType === 'ALL' && sliderDates.length > 0 && (
+        <div className="slider-container">
+          <DateSlider
+            id="chicago-date-slider"
+            dates={sliderDates}
+            value={selectedDate}
+            onChange={handleDateChange}
+            width={MAP_WIDTH}
+          />
+        </div>
+      )}
+
+      {selectedId && lineData && (
+        <div className="svg-graphs">
+          <div className="graph-header">
+            <h2 className="graph-title">{activeNeighborhoodName}</h2>
+            <button className="graph-back" onClick={() => handleSelect(null)} type="button">
+              Back to overview
+            </button>
+          </div>
+
+          <div className="graph-row">
+            <LineGraph
+              data={lineData}
+              keys={['crimeTally', 'crimeTally-mean']}
+              startingDataset={selectedId}
+              width={GRAPH_WIDTH}
+              height={GRAPH_HEIGHT}
+              label="Crime Tally"
+              keyLabel={lineKeyLabel}
+              showTooltips
+            />
+          </div>
+
+          {areaData && (
+            <div className="graph-row">
+              <AreaChart
+                data={areaData}
+                width={GRAPH_WIDTH}
+                height={GRAPH_HEIGHT}
+                label="Crime Type Breakdown"
+                keyLabel={areaKeyLabel}
+                showTooltips
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/pages/NorthCarolina.tsx
+++ b/src/components/pages/NorthCarolina.tsx
@@ -1,0 +1,404 @@
+/**
+ * NorthCarolina — React island for the gerrymandering visualization page.
+ *
+ * Ports apps/north-carolina/ (Backbone + D3 v3) to a typed React + D3 v7 island.
+ * URL contract: ?area=official-2012|splitline|brian  ?hover=<districtId>
+ */
+'use client';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { SvgMap, type SvgMapProps } from '@/components/SvgMap';
+import { parseGraphState, serializeGraphState } from '@/lib/url-state';
+import type { ColorDatum, NCCensusTract } from '@/types';
+
+type SvgMapTopology = SvgMapProps['topology'];
+
+type MapType = 'official-2012' | 'splitline' | 'brian';
+type MetricKey =
+  | 'white'
+  | 'black'
+  | 'republican'
+  | 'democrat'
+  | 'bachelors'
+  | 'poverty'
+  | 'veteran'
+  | 'employed'
+  | 'unemployed';
+
+const METRICS: MetricKey[] = [
+  'white',
+  'black',
+  'republican',
+  'democrat',
+  'bachelors',
+  'poverty',
+  'veteran',
+  'employed',
+  'unemployed',
+];
+
+const METRIC_LABELS: Record<MetricKey, string> = {
+  white: 'White',
+  black: 'Black',
+  republican: 'Republican',
+  democrat: 'Democrat',
+  bachelors: "Bachelor's degree",
+  poverty: 'Below poverty line',
+  veteran: 'Veterans',
+  employed: 'Employed',
+  unemployed: 'Unemployed',
+};
+
+/** Percentage-based metrics (need normalization by pop). Vote share already 0–100. */
+const POP_NORMALIZED: Set<MetricKey> = new Set([
+  'white',
+  'black',
+  'bachelors',
+  'poverty',
+  'veteran',
+  'employed',
+  'unemployed',
+]);
+
+/** Parse CPVI string like "d+16" or "r+11" into a numeric lean. */
+function parseCpvi(cpvi: string): { party: 'D' | 'R'; lean: number } {
+  const match = cpvi.match(/^([dr])\+(\d+)$/i);
+  if (!match) return { party: 'R', lean: 0 };
+  return {
+    party: match[1].toUpperCase() as 'D' | 'R',
+    lean: parseInt(match[2], 10),
+  };
+}
+
+/** Aggregate census tracts by district. Returns { districtId → { metric → value } }. */
+function aggregateByDistrict(tracts: NCCensusTract[]): Map<string, Record<string, number>> {
+  const sums = new Map<string, Record<string, number> & { _pop: number }>();
+
+  for (const tract of tracts) {
+    const d = tract.district;
+    if (!sums.has(d)) {
+      sums.set(d, {
+        _pop: 0,
+        white: 0,
+        black: 0,
+        bachelors: 0,
+        poverty: 0,
+        veteran: 0,
+        employed: 0,
+        unemployed: 0,
+        democrat: 0,
+        republican: 0,
+      });
+    }
+    const row = sums.get(d)!;
+    row._pop += tract.pop;
+    for (const key of METRICS) {
+      row[key] += (tract[key] as number) ?? 0;
+    }
+  }
+
+  const result = new Map<string, Record<string, number>>();
+  for (const [districtId, row] of sums) {
+    const normalized: Record<string, number> = {};
+    for (const key of METRICS) {
+      if (POP_NORMALIZED.has(key)) {
+        normalized[key] = row._pop > 0 ? (row[key] / row._pop) * 100 : 0;
+      } else {
+        // democrat / republican are already vote-share percentages averaged per tract;
+        // take a weighted average.
+        normalized[key] = row._pop > 0 ? row[key] / (sums.get(districtId)?._pop ?? 1) : 0;
+      }
+    }
+    result.set(districtId, normalized);
+  }
+  return result;
+}
+
+// TopoJSON topology type (opaque from topojson-client perspective)
+type Topology = object;
+
+const NC_ROTATE: [number, number] = [80, 0];
+
+export function NorthCarolina() {
+  const [topoOfficial, setTopoOfficial] = useState<Topology | null>(null);
+  const [topoSplitline, setTopoSplitline] = useState<Topology | null>(null);
+  const [tracts, setTracts] = useState<NCCensusTract[]>([]);
+  const [cpvi, setCpvi] = useState<Record<string, string>>({});
+  const [mapType, setMapType] = useState<MapType>('official-2012');
+  const [metric, setMetric] = useState<MetricKey>('white');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Fetch all data on mount
+  useEffect(() => {
+    const base = '/data/north-carolina';
+    Promise.all([
+      fetch(`${base}/north-carolina-2012-districts.json`).then((r) => r.json()),
+      fetch(`${base}/shortest-splitline.json`).then((r) => r.json()),
+      fetch(`${base}/display-data.json`).then((r) => r.json()),
+      fetch(`${base}/cpvi.json`).then((r) => r.json()),
+    ])
+      .then(([official, splitline, displayData, cpviData]) => {
+        setTopoOfficial(official as Topology);
+        setTopoSplitline(splitline as Topology);
+        setTracts(displayData as NCCensusTract[]);
+        setCpvi(cpviData as Record<string, string>);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  // Parse URL state on mount
+  useEffect(() => {
+    const state = parseGraphState(window.location.search);
+    if (state.kind === 'area') {
+      const area = state.area as MapType;
+      if (area === 'official-2012' || area === 'splitline' || area === 'brian') {
+        setMapType(area);
+      }
+      if (state.hover) setSelectedId(state.hover);
+    }
+  }, []);
+
+  // Push URL state when mapType or selectedId changes
+  useEffect(() => {
+    const qs = serializeGraphState(
+      selectedId
+        ? { kind: 'area', area: mapType, hover: selectedId }
+        : { kind: 'area', area: mapType },
+    );
+    const url = qs ? `?${qs}` : window.location.pathname;
+    window.history.replaceState(null, '', url);
+  }, [mapType, selectedId]);
+
+  // Aggregate tracts by district
+  const districtData = useMemo(() => aggregateByDistrict(tracts), [tracts]);
+
+  // Build colorData for the current metric
+  const colorData = useMemo<ColorDatum[]>(() => {
+    const entries: ColorDatum[] = [];
+    for (const [districtId, values] of districtData) {
+      entries.push({ id: districtId, value: values[metric] ?? 0 });
+    }
+    return entries;
+  }, [districtData, metric]);
+
+  // Sorted district ids for bar chart
+  const sortedDistricts = useMemo(
+    () =>
+      [...districtData.keys()].sort((a, b) => {
+        const va = districtData.get(a)?.[metric] ?? 0;
+        const vb = districtData.get(b)?.[metric] ?? 0;
+        return vb - va;
+      }),
+    [districtData, metric],
+  );
+
+  const activeTopology = mapType === 'splitline' ? topoSplitline : topoOfficial;
+
+  const handleSelect = useCallback((id: string | null) => {
+    setSelectedId(id);
+  }, []);
+
+  const handleHover = useCallback((id: string | null) => {
+    setHoveredId(id);
+  }, []);
+
+  const handleMapType = useCallback((type: MapType) => {
+    setMapType(type);
+    setSelectedId(null);
+  }, []);
+
+  const maxVal = useMemo(
+    () => Math.max(...[...districtData.values()].map((v) => v[metric] ?? 0), 1),
+    [districtData, metric],
+  );
+
+  if (loading) {
+    return (
+      <div className="nc-loading">
+        <p>Loading North Carolina data…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="nc-page">
+      {/* Page header */}
+      <h1 className="nc-title">Gerrymandering in North Carolina</h1>
+
+      {/* Map type selector */}
+      <nav className="nc-map-type">
+        <span className="nc-map-type-label">Ways to draw districts: </span>
+        {(['official-2012', 'splitline', 'brian'] as MapType[]).map((type, i) => (
+          <span key={type}>
+            {i > 0 && <span className="nc-sep"> | </span>}
+            <button
+              className={`nc-map-link faux-underline-hover${mapType === type ? ' nc-map-link--active' : ''}`}
+              onClick={() => handleMapType(type)}
+            >
+              {type}
+            </button>
+          </span>
+        ))}
+      </nav>
+
+      <div className="nc-main">
+        {/* Left: map + metric selector */}
+        <div className="nc-map-col">
+          {mapType === 'brian' ? (
+            <div className="nc-brian-unavailable">
+              <p>
+                The Brian Olsen district map is not available. No data file exists for this map
+                type.
+              </p>
+            </div>
+          ) : activeTopology ? (
+            <SvgMap
+              topology={activeTopology as SvgMapTopology}
+              objectKey="districts"
+              width={500}
+              height={600}
+              rotate={NC_ROTATE}
+              scale={2}
+              translateX={280}
+              translateY={-100}
+              colorData={colorData}
+              colorMin={0}
+              colorMax={100}
+              selectedId={selectedId}
+              hoveredId={hoveredId}
+              onSelect={handleSelect}
+              onHover={handleHover}
+              zoomOnClick={false}
+              reverseColorKey={false}
+              title={METRIC_LABELS[metric]}
+              formatHoverText={(id) => {
+                const val = districtData.get(id)?.[metric] ?? 0;
+                const cpviStr = cpvi[id] ?? '';
+                return `District ${id}: ${val.toFixed(1)}% ${cpviStr ? `(${cpviStr.toUpperCase()})` : ''}`;
+              }}
+            />
+          ) : (
+            <p>Map data unavailable.</p>
+          )}
+
+          {/* Metric selector */}
+          <div className="nc-metrics">
+            <span className="nc-metrics-label">Metric: </span>
+            {METRICS.map((m, i) => (
+              <span key={m}>
+                {i > 0 && <span className="nc-sep"> | </span>}
+                <button
+                  className={`nc-metric-link faux-underline-hover${metric === m ? ' nc-metric-link--active' : ''}`}
+                  onClick={() => setMetric(m)}
+                >
+                  {METRIC_LABELS[m]}
+                </button>
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* Right: bar chart */}
+        <div className="nc-chart-col">
+          <h2 className="nc-chart-title">{METRIC_LABELS[metric]} by district</h2>
+          <svg
+            className="nc-bar-chart"
+            width={300}
+            height={sortedDistricts.length * 28 + 20}
+            role="img"
+            aria-label={`Bar chart: ${METRIC_LABELS[metric]} by NC congressional district`}
+          >
+            {sortedDistricts.map((districtId, i) => {
+              const val = districtData.get(districtId)?.[metric] ?? 0;
+              const barWidth = Math.max(0, (val / maxVal) * 220);
+              const cpviStr = cpvi[districtId] ?? '';
+              const { party } = parseCpvi(cpviStr);
+              const barColor = party === 'D' ? '#5b8dd9' : '#d95b5b';
+              const y = i * 28 + 10;
+              return (
+                <g
+                  key={districtId}
+                  className={`nc-bar-group${selectedId === districtId ? ' nc-bar-group--selected' : ''}`}
+                  onClick={() => handleSelect(districtId === selectedId ? null : districtId)}
+                  style={{ cursor: 'pointer' }}
+                >
+                  <text x={28} y={y + 13} fontSize={11} textAnchor="end" fill="currentColor">
+                    {districtId}
+                  </text>
+                  <rect
+                    x={32}
+                    y={y}
+                    width={barWidth}
+                    height={18}
+                    fill={barColor}
+                    opacity={selectedId && selectedId !== districtId ? 0.4 : 0.85}
+                  />
+                  <text x={32 + barWidth + 4} y={y + 13} fontSize={10} fill="currentColor">
+                    {val.toFixed(1)}%{cpviStr ? ` (${cpviStr.toUpperCase()})` : ''}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+        </div>
+      </div>
+
+      {/* Essay text */}
+      <article className="nc-essay">
+        <p>
+          Gerrymandering is a strange little political practice. It shakes the foundations of
+          democracy by allowing some people to intentionally make other people&rsquo;s votes not
+          matter. The sad thing about gerrymandering is that both political parties&rsquo; hands are
+          dirty &mdash; it is common practice to redraw congressional boundaries in one&rsquo;s
+          favor whenever a party gets into power.
+        </p>
+
+        <h2>What is Gerrymandering?</h2>
+        <p>
+          When redistricting happens, existing boundaries are moved to put people who vote for the
+          opposing party together into a small number of districts, limiting their influence.
+          Gerrymandering works when a party wins the most seats in a state by concentrating the
+          other party&rsquo;s voters into a small number of lopsided seats.
+        </p>
+        <blockquote>
+          &ldquo;In North Carolina, where the two-party House vote was 51 percent Democratic, 49
+          percent Republican, the average simulated delegation was seven Democrats and six
+          Republicans. The actual outcome? Four Democrats, nine Republicans &mdash; a split that
+          occurred in less than 1 percent of simulations.&rdquo;
+          <br />
+          <cite>
+            &mdash;{' '}
+            <a
+              href="http://www.nytimes.com/2013/02/03/opinion/sunday/the-great-gerrymander-of-2012.html"
+              className="faux-underline-hover"
+            >
+              Sam Wang, NYTimes
+            </a>
+          </cite>
+        </blockquote>
+
+        <h2>What is a &ldquo;fair&rdquo; congressional district?</h2>
+        <p>
+          Perhaps what makes drawing congressional districts so difficult is that it is hard to
+          agree on what creates a &ldquo;fair&rdquo; district. The broad metric is that every
+          person&rsquo;s vote should be equal. No group should have more or less power through how
+          their voting district is drawn. The maps above let you compare the official 2012 North
+          Carolina districts against a &ldquo;splitline&rdquo; algorithmic approach that draws
+          districts using only population equality as a constraint.
+        </p>
+
+        <h2>Why Now?</h2>
+        <p>
+          I genuinely believe computers should be drawing our district lines, but I am well aware of
+          the problems of having computers solve problems that humans can&rsquo;t agree on. Instead
+          of redrawing districts after every election, computer-controlled districting would simply
+          update as the population changes over time. While automated districting certainly has some
+          bias, it is an intriguing solution since it is &ldquo;less bad&rdquo; on many levels and
+          less susceptible to corruption.
+        </p>
+      </article>
+    </div>
+  );
+}

--- a/src/components/pages/ThreeOneOne.tsx
+++ b/src/components/pages/ThreeOneOne.tsx
@@ -1,0 +1,305 @@
+/**
+ * NYC 311 page component — typed React + D3 v7 port of `apps/311/`.
+ *
+ * Fetches data lazily from /public/data/311/ on mount; no data bundled.
+ * URL deep-link contract: ?area=<id> ?hover=<id> ?type=<abbrev> ?date=<ms>
+ */
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { AreaChart } from '@/components/AreaChart';
+import { DateSlider } from '@/components/DateSlider';
+import { LineGraph } from '@/components/LineGraph';
+import { Select } from '@/components/Select';
+import { SvgMap } from '@/components/SvgMap';
+import type { AreaData } from '@/lib/area-chart';
+import { formatName } from '@/lib/format';
+import type { LineGraphData } from '@/lib/line-chart';
+import { parseGraphState, serializeGraphState } from '@/lib/url-state';
+import type { ColorDatum, DataPoint, ThreeOneOneData } from '@/types';
+
+const DEFAULT_AREA = 'BK60';
+const MAP_WIDTH = 500;
+const MAP_HEIGHT = 400;
+const CHART_WIDTH = 490;
+const CHART_HEIGHT = 230;
+const SLIDER_WIDTH = 502;
+const IGNORED_IDS = ['99', '98'];
+
+export function ThreeOneOne() {
+  const [data, setData] = useState<ThreeOneOneData | null>(null);
+  const [complaintTypes, setComplaintTypes] = useState<Record<string, string>>({});
+  const [topology, setTopology] = useState<unknown>(null);
+  const [neighborhoodNames, setNeighborhoodNames] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+
+  const [selectedId, setSelectedId] = useState<string>(DEFAULT_AREA);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [selectedType, setSelectedType] = useState<string>('ALL');
+  const [selectedDate, setSelectedDate] = useState<number>(0);
+
+  useEffect(() => {
+    Promise.all([
+      fetch('/data/311/display-data.json').then((r) => r.json()),
+      fetch('/data/311/complaint-types.json').then((r) => r.json()),
+      fetch('/data/311/nyc.json').then((r) => r.json()),
+      fetch('/data/311/nyc-neighborhood-names.json').then((r) => r.json()),
+    ]).then(([displayData, typesRaw, topo, names]) => {
+      const typedData = displayData as ThreeOneOneData;
+      // complaint-types.json = { label: abbrev } — invert to { abbrev: label }
+      const typesInverted = Object.fromEntries(
+        Object.entries(typesRaw as Record<string, string>).map(([label, abbrev]) => [
+          abbrev,
+          label,
+        ]),
+      );
+      setData(typedData);
+      setComplaintTypes(typesInverted);
+      setTopology(topo);
+      setNeighborhoodNames(names as Record<string, string>);
+
+      const tally = typedData['ALL']?.complaintTally ?? [];
+      const lastDate = tally[tally.length - 1]?.date ?? 0;
+
+      const graphState = parseGraphState(window.location.search);
+      if (graphState.kind === 'area') {
+        setSelectedId(graphState.area);
+        if (graphState.hover) setHoveredId(graphState.hover);
+        setSelectedDate(lastDate);
+      } else if (graphState.kind === 'type') {
+        setSelectedType(graphState.type);
+        setSelectedDate(lastDate);
+      } else if (graphState.kind === 'date') {
+        setSelectedDate(graphState.date);
+      } else {
+        setSelectedDate(lastDate);
+      }
+
+      setLoading(false);
+    });
+  }, []);
+
+  const pushUrl = useCallback((qs: string) => {
+    window.history.replaceState(null, '', qs ? `?${qs}` : window.location.pathname);
+  }, []);
+
+  const handleSelect = useCallback(
+    (id: string | null) => {
+      const next = id ?? DEFAULT_AREA;
+      setSelectedId(next);
+      pushUrl(serializeGraphState({ kind: 'area', area: next }));
+    },
+    [pushUrl],
+  );
+
+  const handleHover = useCallback(
+    (id: string | null) => {
+      setHoveredId(id);
+      if (id) {
+        pushUrl(serializeGraphState({ kind: 'area', area: selectedId, hover: id }));
+      } else {
+        pushUrl(serializeGraphState({ kind: 'area', area: selectedId }));
+      }
+    },
+    [pushUrl, selectedId],
+  );
+
+  const handleTypeChange = useCallback(
+    (value: string) => {
+      setSelectedType(value);
+      if (value === 'ALL') {
+        pushUrl('');
+      } else {
+        pushUrl(serializeGraphState({ kind: 'type', type: value }));
+      }
+    },
+    [pushUrl],
+  );
+
+  const handleDateChange = useCallback(
+    (date: number) => {
+      setSelectedDate(date);
+      pushUrl(serializeGraphState({ kind: 'date', date }));
+    },
+    [pushUrl],
+  );
+
+  const allDates = useMemo(
+    () => (data?.['ALL']?.complaintTally ?? []).map((d) => d.date).sort((a, b) => a - b),
+    [data],
+  );
+
+  const activeDate = useMemo(() => {
+    if (!allDates.length) return 0;
+    if (!selectedDate) return allDates[allDates.length - 1] ?? 0;
+    return allDates.reduce((prev, cur) =>
+      Math.abs(cur - selectedDate) < Math.abs(prev - selectedDate) ? cur : prev,
+    );
+  }, [allDates, selectedDate]);
+
+  const colorData: ColorDatum[] = useMemo(() => {
+    if (!data) return [];
+    return Object.entries(data)
+      .filter(([id]) => id !== 'ALL' && !IGNORED_IDS.some((ig) => id.includes(ig)))
+      .map(([id, neighborhood]) => {
+        const tally = neighborhood.complaintTally ?? [];
+        const point = tally.find((p) => p.date === activeDate);
+        return { id, value: point?.value ?? 0 };
+      });
+  }, [data, activeDate]);
+
+  const selectOptions = useMemo(() => {
+    if (!data) return {};
+    const allTypes = data['ALL']?.complaintType ?? {};
+    return Object.fromEntries(
+      Object.entries(complaintTypes).filter(([abbrev]) => abbrev in allTypes),
+    );
+  }, [data, complaintTypes]);
+
+  const lineGraphData: LineGraphData = useMemo(() => {
+    if (!data) return {};
+    const activeId = selectedId in data ? selectedId : DEFAULT_AREA;
+    const result: Record<string, Record<string, DataPoint[]>> = {
+      ALL: { 'complaintTally-mean': data['ALL']?.['complaintTally-mean'] ?? [] },
+    };
+    result[activeId] = { complaintTally: data[activeId]?.complaintTally ?? [] };
+    return result;
+  }, [data, selectedId]);
+
+  const areaData = useMemo(() => {
+    if (!data) return {} as AreaData;
+    const activeId = selectedId in data ? selectedId : DEFAULT_AREA;
+    return (data[activeId]?.complaintType ?? {}) as unknown as AreaData;
+  }, [data, selectedId]);
+
+  const formatHoverText = useCallback(
+    (id: string) => {
+      const name = neighborhoodNames[id];
+      return name ? (formatName(name) ?? name) : id;
+    },
+    [neighborhoodNames],
+  );
+
+  const keyLabel = useCallback(
+    (abbrev: string) => complaintTypes[abbrev] ?? abbrev,
+    [complaintTypes],
+  );
+
+  const activeNeighborhoodName = useMemo(() => {
+    const name = neighborhoodNames[selectedId];
+    return name ? (formatName(name) ?? name) : selectedId;
+  }, [neighborhoodNames, selectedId]);
+
+  if (loading || !topology || !data) {
+    return (
+      <div id="three" className="map-app">
+        <p style={{ padding: '2rem' }}>Loading 311 data…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div id="three" className="map-app">
+      <header>
+        <div className="heading">311 Calls in NYC from 2010–2014</div>
+        <div className="border" />
+      </header>
+
+      <div className="map-svg-container">
+        <div className="select-container visible" style={{ marginBottom: '8px' }}>
+          <label htmlFor="three-select">Filter 311 reports: </label>
+          <Select
+            id="three-select"
+            options={selectOptions}
+            value={selectedType}
+            onChange={handleTypeChange}
+            includeAll
+          />
+        </div>
+
+        <SvgMap
+          topology={topology as Parameters<typeof SvgMap>[0]['topology']}
+          objectKey="neighborhoods"
+          width={MAP_WIDTH}
+          height={MAP_HEIGHT}
+          scale={1.3}
+          translateX={-50}
+          translateY={20}
+          ignoredIds={IGNORED_IDS}
+          colorData={colorData}
+          colorMin={0}
+          colorMax={50}
+          selectedId={selectedId}
+          hoveredId={hoveredId ?? undefined}
+          onSelect={handleSelect}
+          onHover={handleHover}
+          title="311 Reports per 1,000 residents"
+          formatHoverText={formatHoverText}
+        />
+
+        {allDates.length > 0 && (
+          <DateSlider
+            id="three-date-slider"
+            dates={allDates}
+            value={activeDate}
+            onChange={handleDateChange}
+            width={SLIDER_WIDTH}
+          />
+        )}
+      </div>
+
+      <div className="svg-graphs">
+        <p className="graph-help-text">Click on a neighborhood to see how the residents use 311.</p>
+        <div className="svg-graphs-content">
+          <div className="graph-heading-container">
+            <div className="selected-neighborhood-name">
+              <span className="circle-key blue" />
+              <span className="graph-heading">{activeNeighborhoodName}</span>
+            </div>
+            <div className="avg-neighborhood-name">
+              <span className="circle-key gray" />
+              <span className="graph-heading">Borough Average</span>
+            </div>
+          </div>
+
+          <LineGraph
+            data={lineGraphData}
+            keys={['complaintTally', 'complaintTally-mean']}
+            startingDataset={selectedId in (data ?? {}) ? selectedId : DEFAULT_AREA}
+            width={CHART_WIDTH}
+            height={CHART_HEIGHT}
+            label={`311 Calls: ${activeNeighborhoodName}`}
+            keyLabel={(key) =>
+              key === 'complaintTally-mean' ? 'Borough Average' : activeNeighborhoodName
+            }
+            showTooltips
+          />
+
+          <AreaChart
+            data={areaData}
+            width={CHART_WIDTH}
+            height={CHART_HEIGHT}
+            label="Complaint Type Breakdown"
+            keyLabel={keyLabel}
+            showTooltips
+          />
+        </div>
+      </div>
+
+      <div className="markdown-text">
+        <time dateTime="2015-01-22">January 22, 2015</time>
+        <h1>How 311 Data can help us understand NYC</h1>
+        <p>
+          311 is New York City&rsquo;s non-emergency government services hotline. From noise
+          complaints to pothole reports, the 7.7 million calls made from 2010 to 2014 reveal how
+          residents interact with city services across every neighborhood.
+        </p>
+        <p>
+          Click any neighborhood on the map to see its complaint history and breakdown by type,
+          compared to the borough average.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/311.astro
+++ b/src/pages/311.astro
@@ -1,0 +1,23 @@
+---
+/**
+ * NYC 311 page — /311
+ *
+ * URL contract (must keep resolving — see MIGRATION.md §3):
+ *   /311                      → overview (default area BK60)
+ *   /311?area=<id>            → selected neighborhood
+ *   /311?area=<id>&hover=<id> → selected + hovered
+ *   /311?type=<abbrev>        → complaint-type filter
+ *   /311?date=<epochMs>       → selected date
+ *
+ * Data is fetched lazily by the ThreeOneOne island on the client from /data/311/.
+ */
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import { ThreeOneOne } from '@/components/pages/ThreeOneOne';
+---
+
+<BaseLayout
+  title="NYC 311 Calls — Vislet"
+  description="Compare how 7.7 million 311 calls are distributed across NYC neighborhoods from 2010 to 2014."
+>
+  <ThreeOneOne client:only="react" />
+</BaseLayout>

--- a/src/pages/brooklyn.astro
+++ b/src/pages/brooklyn.astro
@@ -1,0 +1,22 @@
+---
+/**
+ * Brooklyn page — /brooklyn
+ *
+ * URL contract (must keep resolving — see MIGRATION.md §3):
+ *   /brooklyn              → overview (default neighborhood BK60)
+ *   /brooklyn?area=<id>   → selected neighborhood
+ *   /brooklyn?area=<id>&hover=<id2> → selected + hovered
+ *   /brooklyn?date=<ms>   → selected date
+ *
+ * Data is fetched lazily by the Brooklyn island on the client from /data/brooklyn/.
+ */
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import { Brooklyn } from '@/components/pages/Brooklyn';
+---
+
+<BaseLayout
+  title="Brooklyn Property Sales — Vislet"
+  description="A look at 322,056 property sales in Brooklyn from 2003 to 2014."
+>
+  <Brooklyn client:only="react" />
+</BaseLayout>

--- a/src/pages/chicago.astro
+++ b/src/pages/chicago.astro
@@ -1,0 +1,17 @@
+---
+/**
+ * Chicago Crime page — /chicago
+ *
+ * Ports apps/chicago. The React island owns all data fetching, state, and
+ * URL deep-link wiring. BaseLayout supplies the shared header/footer.
+ */
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import { Chicago } from '@/components/pages/Chicago';
+---
+
+<BaseLayout
+  title="Chicago Crime 2003-2014 — Vislet"
+  description="5,712,201 crimes shown across Chicago neighborhoods from 2003 to 2014."
+>
+  <Chicago client:only="react" />
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,19 +1,82 @@
 ---
 /**
- * Home page (placeholder).
+ * Home page — featured projects list.
  *
- * The shared layout (header/intro/footer + site nav) is exercised here so the
- * scaffold builds and renders. Full home content and the four visualization
- * pages are migrated in Phase 2.2 — this stub only validates the layout.
+ * Ports apps/home/templates/index.jade. The VISLET title, subtitle, and nav
+ * are already rendered by BaseLayout's vislet-intro header, so this page only
+ * outputs the "Featured Projects" section.
  */
 import BaseLayout from '@/layouts/BaseLayout.astro';
+
+const projects = [
+  {
+    href: '/brooklyn',
+    name: 'Brooklyn Property Sales',
+    description: 'A look at 322,056 property sales in Brooklyn from 2003 to 2014.',
+  },
+  {
+    href: '/311',
+    name: 'NYC 311 Calls',
+    description: 'Compare how 7.7 million 311 calls are distributed across NYC from 2010 to 2014.',
+  },
+  {
+    href: '/chicago',
+    name: 'Chicago Crime',
+    description: '5,712,201 crimes in shown across the city of Chicago from 2003 to 2014.',
+  },
+];
 ---
 
 <BaseLayout>
-  <section class="prose">
-    <p>
-      Vislet is being migrated to a modern Astro + React + D3 v7 stack. The shared layout is live;
-      the interactive visualizations are ported one at a time.
-    </p>
+  <section class="featured-projects">
+    <h2 class="section-title">Featured Projects</h2>
+    <ul class="project-list">
+      {
+        projects.map((project) => (
+          <li class="project-item">
+            <a class="project-link faux-underline-hover" href={project.href}>
+              {project.name}
+            </a>
+            <p class="project-description">{project.description}</p>
+          </li>
+        ))
+      }
+    </ul>
   </section>
 </BaseLayout>
+
+<style>
+  .featured-projects {
+    margin-top: 2rem;
+  }
+
+  .section-title {
+    border-bottom: 1px solid currentColor;
+    padding-bottom: 0.25rem;
+    margin-bottom: 1.25rem;
+    font-size: 1rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .project-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  .project-link {
+    font-weight: 700;
+    font-size: 1rem;
+    text-decoration: none;
+  }
+
+  .project-description {
+    margin: 0.25rem 0 0;
+    font-size: 0.9rem;
+  }
+</style>

--- a/src/pages/north-carolina.astro
+++ b/src/pages/north-carolina.astro
@@ -1,0 +1,174 @@
+---
+/**
+ * North Carolina gerrymandering visualization page.
+ *
+ * Ports apps/north-carolina/ to Astro + React. URL contract:
+ *   /north-carolina                            → overview (official-2012, white)
+ *   /north-carolina?area=official-2012         → official districts map
+ *   /north-carolina?area=splitline             → splitline map
+ *   /north-carolina?area=brian                 → shows "not available" message
+ *   /north-carolina?area=<type>&hover=<id>     → hover/selected state
+ */
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import { NorthCarolina } from '@/components/pages/NorthCarolina';
+---
+
+<BaseLayout
+  title="Gerrymandering in North Carolina — Vislet"
+  description="An interactive look at North Carolina's congressional districts: compare official 2012 boundaries against algorithmic alternatives, colored by demographic and electoral metrics."
+>
+  <NorthCarolina client:only="react" />
+</BaseLayout>
+
+<style>
+  :global(.nc-page) {
+    padding: 1rem 0 3rem;
+  }
+
+  :global(.nc-loading) {
+    padding: 2rem 0;
+    color: #666;
+  }
+
+  :global(.nc-title) {
+    font-size: 1.4rem;
+    font-weight: 700;
+    margin-bottom: 0.75rem;
+  }
+
+  :global(.nc-map-type) {
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+  }
+
+  :global(.nc-map-type-label) {
+    font-weight: 700;
+    margin-right: 0.25rem;
+  }
+
+  :global(.nc-map-link) {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+    color: inherit;
+  }
+
+  :global(.nc-map-link--active) {
+    font-weight: 700;
+  }
+
+  :global(.nc-metric-link) {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+    color: inherit;
+  }
+
+  :global(.nc-metric-link--active) {
+    font-weight: 700;
+  }
+
+  :global(.nc-sep) {
+    color: #999;
+  }
+
+  :global(.nc-main) {
+    display: flex;
+    gap: 2rem;
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  :global(.nc-map-col) {
+    flex: 0 0 auto;
+  }
+
+  :global(.nc-metrics) {
+    margin-top: 0.75rem;
+    font-size: 0.85rem;
+    max-width: 500px;
+    line-height: 1.8;
+  }
+
+  :global(.nc-metrics-label) {
+    font-weight: 700;
+    margin-right: 0.25rem;
+  }
+
+  :global(.nc-chart-col) {
+    flex: 1 1 280px;
+    min-width: 260px;
+  }
+
+  :global(.nc-chart-title) {
+    font-size: 0.95rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  :global(.nc-bar-chart) {
+    display: block;
+    overflow: visible;
+  }
+
+  :global(.nc-bar-group) {
+    transition: opacity 0.15s;
+  }
+
+  :global(.nc-bar-group--selected rect) {
+    stroke: #333;
+    stroke-width: 1.5px;
+  }
+
+  :global(.nc-brian-unavailable) {
+    width: 500px;
+    height: 200px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px dashed #ccc;
+    border-radius: 4px;
+    color: #666;
+    font-size: 0.95rem;
+    text-align: center;
+    padding: 1rem;
+  }
+
+  :global(.nc-essay) {
+    margin-top: 2.5rem;
+    max-width: 700px;
+    font-size: 0.95rem;
+    line-height: 1.7;
+  }
+
+  :global(.nc-essay h2) {
+    font-size: 1.05rem;
+    font-weight: 700;
+    margin: 1.5rem 0 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  :global(.nc-essay blockquote) {
+    border-left: 3px solid #ccc;
+    margin: 1rem 0 1rem 0;
+    padding: 0.5rem 1rem;
+    color: #555;
+    font-style: italic;
+  }
+
+  :global(.nc-essay cite) {
+    font-style: normal;
+    font-size: 0.85rem;
+  }
+
+  :global(.nc-essay p) {
+    margin-bottom: 0.75rem;
+  }
+</style>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -38,3 +38,225 @@ body {
 .faux-underline-large {
   text-decoration: none;
 }
+
+/* ==========================================================================
+   Visualization chart + map styles
+   Ported from legacy Stylus per-app stylesheets.
+   ========================================================================== */
+
+/* Choropleth map paths */
+.tract {
+  fill: #ccc;
+  stroke: #fff;
+  stroke-width: 0.5px;
+  cursor: pointer;
+}
+.tract.selected {
+  stroke: #333;
+  stroke-width: 1.5px;
+}
+.tract.park {
+  fill: url(#hatch);
+  cursor: default;
+}
+
+/* 9 choropleth color classes (color0=lightest, color8=darkest red) */
+.tract.color0 {
+  fill: #fee5d9;
+}
+.tract.color1 {
+  fill: #fcbba1;
+}
+.tract.color2 {
+  fill: #fc9272;
+}
+.tract.color3 {
+  fill: #fb6a4a;
+}
+.tract.color4 {
+  fill: #ef3b2c;
+}
+.tract.color5 {
+  fill: #cb181d;
+}
+.tract.color6 {
+  fill: #a50f15;
+}
+.tract.color7 {
+  fill: #67000d;
+}
+.tract.color8 {
+  fill: #40000a;
+}
+
+/* Date slider handle */
+.handle {
+  fill: steelblue;
+  stroke: #fff;
+  stroke-width: 1.5px;
+  cursor: ew-resize;
+}
+
+/* Axis tick/label styles */
+.tick text {
+  font-size: 11px;
+  fill: #555;
+}
+.domain {
+  stroke: #999;
+}
+
+/* Line chart strokes */
+.line {
+  fill: none;
+  stroke-width: 1.5px;
+}
+.trend-area {
+  fill: steelblue;
+  opacity: 0.15;
+}
+
+/* Area chart fills already use inline style from color scale */
+.area {
+  opacity: 0.8;
+}
+
+/* Color key */
+.color-key {
+  display: flex;
+  flex-direction: row;
+}
+.color-key-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 10px;
+}
+.color-key-swatch {
+  height: 8px;
+  width: 100%;
+}
+
+/* Map app layout */
+.map-app {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 16px;
+}
+.map-app header {
+  margin-bottom: 16px;
+}
+.map-app header .heading {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.map-app header .border {
+  border-bottom: 1px solid #333;
+  margin-bottom: 16px;
+}
+.map-svg-container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+.svg-graphs {
+  margin-top: 24px;
+}
+.graph-help-text {
+  font-size: 0.875rem;
+  color: #666;
+  margin-bottom: 12px;
+}
+.graph-heading-container {
+  display: flex;
+  gap: 24px;
+  margin-bottom: 12px;
+  font-size: 0.75rem;
+}
+.circle-key {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 4px;
+}
+.circle-key.blue {
+  background: steelblue;
+}
+.circle-key.red {
+  background: #d53f50;
+}
+.circle-key.gray {
+  background: lightgray;
+}
+.select-container label {
+  font-size: 0.875rem;
+  margin-right: 8px;
+}
+.markdown-text {
+  max-width: 680px;
+  margin-top: 48px;
+  line-height: 1.7;
+}
+.markdown-text h1 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 16px;
+}
+.markdown-text h2 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin-top: 24px;
+  margin-bottom: 8px;
+}
+.markdown-text p {
+  margin-bottom: 12px;
+}
+.markdown-text img {
+  max-width: 100%;
+  margin: 16px 0;
+}
+.markdown-text blockquote {
+  border-left: 3px solid #ccc;
+  padding-left: 16px;
+  color: #555;
+  margin: 16px 0;
+}
+
+/* Home page */
+.projects {
+  margin-top: 32px;
+}
+.project-title {
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.project {
+  display: block;
+  padding: 12px 0;
+  border-bottom: 1px solid #eee;
+  text-decoration: none;
+  color: inherit;
+}
+.project .title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+.project .description {
+  font-size: 0.875rem;
+  color: #555;
+}
+
+/* Back link */
+.back {
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+/* SVG text labels */
+text.label-text,
+text.hover-text {
+  font-size: 11px;
+  fill: #333;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,3 +43,54 @@ export interface ColorDatum {
   id: string;
   value: number;
 }
+
+// ─── NC display-data.json ────────────────────────────────────────────────────
+export interface NCCensusTract {
+  id: string;
+  district: string;
+  point: [number, number];
+  pop: number;
+  white: number;
+  black: number;
+  asian: number;
+  children: number;
+  poverty: number;
+  veteran: number;
+  employed: number;
+  unemployed: number;
+  armed: number;
+  bachelors: number;
+  democrat: number;
+  republican: number;
+  [key: string]: unknown;
+}
+
+// ─── Chicago display-data ────────────────────────────────────────────────────
+export interface ChicagoNeighborhoodData {
+  crimeTally: DataPoint[];
+  crimeType: Record<string, DataPoint[]>;
+}
+export type ChicagoData = Record<
+  string,
+  ChicagoNeighborhoodData & { 'crimeTally-mean'?: DataPoint[] }
+>;
+
+// ─── 311 display-data ────────────────────────────────────────────────────────
+export interface ThreeOneOneNeighborhoodData {
+  complaintTally: DataPoint[];
+  complaintType: Record<string, DataPoint[]>;
+}
+export type ThreeOneOneData = Record<
+  string,
+  ThreeOneOneNeighborhoodData & { 'complaintTally-mean'?: DataPoint[] }
+>;
+
+// ─── Brooklyn display-data ───────────────────────────────────────────────────
+export interface BrooklynNeighborhoodData {
+  residentialPrices: DataPoint[];
+  buildingClass: Record<string, DataPoint[]>;
+}
+export type BrooklynData = Record<
+  string,
+  BrooklynNeighborhoodData & { 'residentialPrices-mean'?: DataPoint[] }
+>;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './__tests__/setup.ts',
+    exclude: ['**/node_modules/**', '**/e2e/**', '**/*.spec.ts'],
     css: true,
     coverage: {
       provider: 'istanbul',


### PR DESCRIPTION
## Summary

- **Home** (`/`): static project listing, fully migrated from `apps/home/templates/index.jade`
- **North Carolina** (`/north-carolina`): choropleth map (official-2012 + splitline district topologies), demographic metric selector (white / black / republican / democrat / bachelors / poverty / veteran / employed / unemployed), CPVI-colored horizontal bar chart per district, gerrymandering essay; `?area=brian` shows graceful "not available" (no topology exists in legacy either)
- **Chicago** (`/chicago`): neighborhood choropleth + crime-type Select + DateSlider + LineGraph + AreaChart; default area 68
- **311** (`/311`): same structure as Chicago, NYC complaint data; default area BK60
- **Brooklyn** (`/brooklyn`): neighborhood choropleth + DateSlider + LineGraph (residential prices) + AreaChart (building class % of sales); no type filter; default area BK60

**Architecture:**
- All interactive pages use `client:only="react"` — no SSR, no data in HTML
- Data fetched lazily on mount from `/public/data/<app>/` (`fetch` in `useEffect`)
- URL deep-link contract fully preserved (`?area`, `?hover`, `?type`, `?date` params, same names as legacy Backbone router)
- Pam's P2.1 component surface consumed (`SvgMap`, `LineGraph`, `AreaChart`, `DateSlider`, `Select`, `url-state`)

**Known gap (follow-up):** NC census-tract circle overlay deferred pending Pam's `SvgMap` overlay prop (tracked separately; choropleth + bar chart + URL state are complete)

## Test plan

- [ ] `npm run typecheck` — 0 errors
- [ ] `npm run lint` — 0 warnings
- [ ] `npm run format:check` — clean
- [ ] `npm run test` — 84 unit tests pass
- [ ] `npm run build` — 5 pages built cleanly, no SSR fetch errors
- [ ] `npm run check` — 0 Astro errors/warnings
- [ ] Manually visit `/`, `/brooklyn`, `/311`, `/chicago`, `/north-carolina` in dev server
- [ ] Verify deep-link URLs: `?area=BK60`, `?type=ASS`, `?date=1041397200000`, `?area=official-2012`, `?area=splitline`
- [ ] `npm run test:e2e` — Playwright smokes for all 5 routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)