### PR TITLE
P2.1 fix: add overlay render-prop to SvgMap for projected point markers

### DIFF
--- a/__tests__/components/SvgMap.test.tsx
+++ b/__tests__/components/SvgMap.test.tsx
@@ -73,4 +73,30 @@ describe('<SvgMap />', () => {
     expect(container.querySelector('.linear-graph-key')).not.toBeNull();
     expect(container.querySelectorAll('.key-bar').length).toBe(9);
   });
+
+  it('renders a children overlay, passing a usable projection that maps lng/lat → px', () => {
+    let projectedAt: [number, number] | null = null;
+    const { container } = render(
+      <SvgMap {...base}>
+        {(projection) => {
+          const xy = projection([0.5, 0.5]);
+          projectedAt = xy as [number, number];
+          return xy ? <circle data-id="tract-1" cx={xy[0]} cy={xy[1]} r={3} /> : null;
+        }}
+      </SvgMap>,
+    );
+    // The render-prop received a working projection (finite px coordinates).
+    expect(projectedAt).not.toBeNull();
+    expect(Number.isFinite(projectedAt![0])).toBe(true);
+    expect(Number.isFinite(projectedAt![1])).toBe(true);
+    // The overlay mark is drawn inside the same zoom <g> as the choropleth paths.
+    const circle = container.querySelector('circle[data-id="tract-1"]');
+    expect(circle).not.toBeNull();
+    expect(circle!.closest('g')!.querySelector('path[data-id]')).not.toBeNull();
+  });
+
+  it('renders no overlay group content when children is omitted (backward-compatible)', () => {
+    const { container } = render(<SvgMap {...base} />);
+    expect(container.querySelector('circle')).toBeNull();
+  });
 });

--- a/src/components/SvgMap.tsx
+++ b/src/components/SvgMap.tsx
@@ -11,13 +11,20 @@
  *     state (and the URL `?area=&hover=` contract via `@/lib/url-state`).
  *   - `onSelect(id | null)` / `onHover(id | null)`: events out (replace the
  *     legacy `Backbone.history.navigate("?area=…")` calls).
+ *   - `children(projection)`: optional render-prop receiving the live
+ *     `GeoProjection`. The consumer projects its own `[lng, lat]` points (e.g.
+ *     NC census-tract circles) and returns SVG to overlay ON TOP of the
+ *     choropleth, inside the same zoom group — so overlays share the map's
+ *     projection AND its click-zoom transform. SvgMap never styles these marks.
  *
  * D3 owns the math (`geoMercator` + `geoPath`, fit-to-bounds, `scaleQuantile`);
  * React owns every `<path>`/`<text>`. Click-zoom is a CSS transform on the
  * group (no `d3.select` transition).
  */
 import { geoMercator, geoPath } from 'd3';
+import type { GeoProjection } from 'd3';
 import type { FeatureCollection, GeoJsonProperties, Geometry } from 'geojson';
+import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 import { feature } from 'topojson-client';
 
@@ -62,6 +69,13 @@ export interface SvgMapProps {
   colorKeyWidth?: number;
   /** Animate a zoom-to-feature on selection (legacy default true). */
   zoomOnClick?: boolean;
+  /**
+   * Optional overlay render-prop. Receives the live `GeoProjection` (already
+   * fit to the viewport) so the consumer can project `[lng, lat]` → `[x, y]`
+   * and return SVG (e.g. `<circle>` tract markers) drawn on top of the
+   * choropleth, within the same zoom group. Omit for a plain choropleth.
+   */
+  children?: (projection: GeoProjection) => ReactNode;
 }
 
 const DEFAULT_ROTATE: [number, number] = [74 + 700 / 60, -38 - 50 / 60];
@@ -88,11 +102,12 @@ export function SvgMap({
   reverseColorKey = true,
   colorKeyWidth,
   zoomOnClick = true,
+  children,
 }: SvgMapProps) {
   const isIgnored = (id: string) => ignoredIds.some((ignored) => id.includes(ignored));
 
   // Build the projection + path generator and fit the features to the viewport.
-  const { features, path } = useMemo(() => {
+  const { features, path, projection } = useMemo(() => {
     const objects = (topology as { objects: Record<string, unknown> }).objects;
     const fc = feature(
       topology,
@@ -110,7 +125,7 @@ export function SvgMap({
       (height - fitScale * (bounds[1][1] + bounds[0][1])) / 2 + translateY,
     ];
     projection.scale(fitScale).translate(translate);
-    return { features: fc.features, path: pathGen };
+    return { features: fc.features, path: pathGen, projection };
   }, [topology, objectKey, width, height, rotate, scale, translateX, translateY]);
 
   // Per-id color class from the quantile scale (mirrors `colorMap`).
@@ -171,6 +186,9 @@ export function SvgMap({
               />
             );
           })}
+          {/* Consumer overlay (e.g. projected tract circles), aligned to the
+              same projection and zoomed with the choropleth. */}
+          {children?.(projection)}
         </g>
         {title && (
           <text className="label-text" x={10} y={20}>


### PR DESCRIPTION
## What & why
Dwight (P2.2 north-carolina) hit a gap: the legacy NC page overlays census-tract **circles** on top of the district choropleth, but `SvgMap` didn't expose its internal projection or accept extra SVG children — so the points couldn't be drawn.

## Change
Adds an optional overlay render-prop to `SvgMap`:

```ts
children?: (projection: GeoProjection) => ReactNode
```

- Exposes the live, viewport-fit `GeoProjection` out of the projection `useMemo`.
- Renders `children(projection)` **inside the zoom `<g>`**, after the feature paths — so overlay marks share the choropleth's projection *and* its click-zoom transform.
- The consumer projects its own `[lng, lat] → [x, y]` and returns SVG (e.g. `<circle>`s). `SvgMap` owns no point styling.

**Backward-compatible:** omitting `children` leaves existing choropleth consumers untouched.

## Consumer usage (for Dwight)
```tsx
<SvgMap {...props}>
  {(projection) =>
    tracts.map((t) => {
      const xy = projection([t.lng, t.lat]);
      return xy ? <circle key={t.id} cx={xy[0]} cy={xy[1]} r={2} className="tract" /> : null;
    })
  }
</SvgMap>
```

## Tests / gates
- 2 new tests: overlay receives a working projection (lng/lat→finite px) and the mark renders in the same `<g>` as the choropleth paths; no-overlay → no stray marks.
- All green: check (0 errors) / lint / typecheck / test (86 pass) / build / format:check.

## Scope
Just this overlay capability — no other SvgMap refactor, no other components touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)