### PR TITLE
P2.2-nc-circles: wire census-tract circle overlay into NorthCarolina

### DIFF
--- a/__tests__/e2e/smoke.spec.ts
+++ b/__tests__/e2e/smoke.spec.ts
@@ -131,4 +131,16 @@ test.describe('North Carolina page (/north-carolina)', () => {
     await expect(page.locator('svg').first()).toBeVisible();
     expect(getErrors()).toHaveLength(0);
   });
+
+  test('census-tract circles render as SVG circle elements', async ({ page }) => {
+    const getErrors = collectErrors(page);
+    await page.goto('/north-carolina', { waitUntil: 'networkidle' });
+
+    // The overlay renders hundreds of <circle> elements inside the choropleth SVG
+    const circles = page.locator('svg circle');
+    await expect(circles.first()).toBeVisible();
+    const count = await circles.count();
+    expect(count).toBeGreaterThan(100);
+    expect(getErrors()).toHaveLength(0);
+  });
 });

--- a/src/components/pages/NorthCarolina.tsx
+++ b/src/components/pages/NorthCarolina.tsx
@@ -5,11 +5,25 @@
  * URL contract: ?area=official-2012|splitline|brian  ?hover=<districtId>
  */
 'use client';
+import { scaleQuantile } from 'd3';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { SvgMap, type SvgMapProps } from '@/components/SvgMap';
 import { parseGraphState, serializeGraphState } from '@/lib/url-state';
 import type { ColorDatum, NCCensusTract } from '@/types';
+
+// Legacy svg-map color0–color8 palette (Spectral, blue→red for low→high)
+const CIRCLE_COLORS = [
+  '#3288bd',
+  '#66c2a5',
+  '#abdda4',
+  '#e6f598',
+  '#ffffbf',
+  '#fee08b',
+  '#fdae61',
+  '#f46d43',
+  '#d53e4f',
+] as const;
 
 type SvgMapTopology = SvgMapProps['topology'];
 
@@ -214,6 +228,19 @@ export function NorthCarolina() {
     [districtData, metric],
   );
 
+  // Per-tract metric value (normalized) + quantile fill color for overlay circles
+  const tractCircleData = useMemo(() => {
+    if (!tracts.length) return [];
+    const vals = tracts.map((t) => {
+      const raw = (t[metric] as number) ?? 0;
+      return POP_NORMALIZED.has(metric) ? (t.pop > 0 ? (raw / t.pop) * 100 : 0) : raw;
+    });
+    const colorScale = scaleQuantile<string>()
+      .domain(vals)
+      .range([...CIRCLE_COLORS]);
+    return tracts.map((t, i) => ({ tract: t, fill: colorScale(vals[i]!) }));
+  }, [tracts, metric]);
+
   if (loading) {
     return (
       <div className="nc-loading">
@@ -278,7 +305,23 @@ export function NorthCarolina() {
                 const cpviStr = cpvi[id] ?? '';
                 return `District ${id}: ${val.toFixed(1)}% ${cpviStr ? `(${cpviStr.toUpperCase()})` : ''}`;
               }}
-            />
+            >
+              {(projection) =>
+                tractCircleData.map(({ tract, fill }) => {
+                  const xy = projection(tract.point as [number, number]);
+                  return xy ? (
+                    <circle
+                      key={tract.id}
+                      cx={xy[0]}
+                      cy={xy[1]}
+                      r={2}
+                      fill={fill}
+                      style={{ pointerEvents: 'none', stroke: 'none' }}
+                    />
+                  ) : null;
+                })
+              }
+            </SvgMap>
           ) : (
             <p>Map data unavailable.</p>
           )}


### PR DESCRIPTION
## Summary

- Wires Pam's `SvgMap` `children` render-prop (landed in #22 / fc795be) into `NorthCarolina.tsx`
- Census tracts rendered as `<circle r={2}>` elements overlaid on the choropleth, colored by a `d3.scaleQuantile` over the active metric using the legacy Spectral 9-stop palette (blue→red for low→high, matching the old `color0`–`color8` CSS classes)
- Metric normalization matches legacy: pop-based metrics (`white`, `black`, `bachelors`, `poverty`, `veteran`, `employed`, `unemployed`) divided by tract population; `democrat`/`republican` used as-is (already vote-share %)
- Point ordering confirmed `[lng, lat]` — no swap needed
- Playwright smoke extended: asserts `>100 <circle>` elements render on `/north-carolina`

## Files changed

- `src/components/pages/NorthCarolina.tsx` — adds `CIRCLE_COLORS` constant, `tractCircleData` memo, `children` render-prop on `SvgMap`
- `__tests__/e2e/smoke.spec.ts` — new test: census-tract circles render

## Test plan

- [ ] `npm run typecheck` — 0 errors
- [ ] `npm run lint` — 0 warnings
- [ ] `npm run format:check` — clean
- [ ] `npm run test` — 86 unit tests pass
- [ ] `npm run build` — 5 pages built cleanly
- [ ] Visit `/north-carolina` in dev server: circles visible over district choropleth; switching metric updates circle colors; switching to splitline map also shows circles
- [ ] `npm run test:e2e` — all smokes pass including new circles assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)