### PR TITLE
infra(deploy): Pages config — clarify prod branch=main + deploy command

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,18 @@
 # Cloudflare Pages configuration.
-# This site is purely static — no Workers/Functions needed.
+# vislet is a purely static Astro site (astro.config.mjs → output: "static" → dist/).
+# Served via classic Cloudflare Pages — no Workers/Functions needed.
 name = "vislet"
 pages_build_output_dir = "dist"
 
-# Build command: `astro build` → output `dist/`.
-# PRs get preview deploys automatically; `master` deploys to production.
+# Deploy model: connect this repo to a Cloudflare **Pages** project (Git integration).
+#   Build command:           npm run build   (astro build → dist/)
+#   Build output directory:  dist
+#   Production branch:        main            (PRs get automatic preview deploys)
+#
+# Manual deploys use `npx wrangler pages deploy dist` — NOT `wrangler deploy`,
+# which is Workers-mode and fails with:
+#   "Missing entry-point to Worker script or to assets directory".
+#
+# Observability: classic Pages has no wrangler `[observability]` block (that is
+# Workers-only, and a no-op for purely static assets). Use Cloudflare Web
+# Analytics (dashboard / RUM beacon) for traffic + Core Web Vitals instead.


### PR DESCRIPTION
## What

Keeps the classic Cloudflare **Pages** model for this purely static Astro site and makes the deploy config unambiguous.

```toml
name = "vislet"
pages_build_output_dir = "dist"
```

- Documents the Git-integration build settings (build cmd `npm run build`, output `dist`, **production branch = main**).
- Fixes the stale `master deploys to production` comment — `master` does not exist on this repo, `main` is the integration/prod branch. (Real footgun for cutover.)
- Calls out the deploy-command pitfall that caused the failed build: use `npx wrangler pages deploy dist`, **not** `wrangler deploy` (Workers mode → 'Missing entry-point to Worker script or to assets directory').

## Why Pages (not Workers)

Per request, we use **Pages** rather than the Workers static-assets model. For a purely static site this is the simpler, canonical path. The wrangler `[observability]` block is Workers-only and a **no-op for static assets** (static hits never invoke a Worker), so nothing is lost.

## Observability under Pages

Use **Cloudflare Web Analytics** (dashboard toggle / RUM beacon) for traffic + Core Web Vitals. Can wire the beacon into the Astro layout as a follow-up if wanted (needs the analytics token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)