### PR TITLE
Align visuals with zamiang-dot-com-v2 + fix three viz UI bugs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,128 @@
+# Design
+
+> Vislet inherits the **"Slate Executive"** system from its sibling repo
+> `zamiang-dot-com-v2`. That repo's `src/styles/globals.css` is the upstream
+> source of truth for shared tokens; this file documents how the system is
+> applied to vislet's editorial home + interactive D3 viz pages. When the two
+> drift, the sibling wins for chrome/voice; vislet adds only what data
+> visualization requires (sequential/choropleth ramps).
+>
+> Canonical local source: `src/styles/globals.css` (`:root` block).
+
+## Theme
+
+Single light mode. Cool, restrained, reading-first, with one warm copper accent.
+The page background is **Cool Mist `#f0f2f5`, never pure white** — this is the
+single most visible consistency lever vs. the sibling. Depth comes from hairline
+rules, generous whitespace, and (optionally) a faint paper-noise overlay — not
+from shadows or gradients.
+
+## Color — "Slate Executive"
+
+| Token                | Hex       | Use                                             |
+| -------------------- | --------- | ----------------------------------------------- |
+| `--background`       | `#f0f2f5` | Page — Cool Mist, never pure white              |
+| `--foreground`       | `#2c333a` | Body / ink — Deep Charcoal Blue                 |
+| `--primary`          | `#5a7684` | Steel Blue — chrome, viz selection/handle       |
+| `--accent`           | `#749ca8` | Dusty Teal — link borders, labels, accents      |
+| `--accent-bold`      | `#c17f59` | Warm Copper — the only warm color; emphasis/CTA |
+| `--muted`            | `#e8eaed` | Fills                                           |
+| `--muted-foreground` | `#4a5560` | Meta, captions, axis labels (AA on Cool Mist)   |
+| `--border`           | `#d1d5db` | Hairline rules, separators                      |
+| `--destructive`      | `#b44d4d` | Errors only                                     |
+| `--success`          | `#5a8a6b` | Confirmation only                               |
+
+### Data-encoding palettes (vislet-only, never overridden by brand color)
+
+- **Sequential choropleth** (311, Chicago, NC): the 9-step ColorBrewer Reds ramp
+  `#fee5d9 → #40000a`. Encodes magnitude; keep for data accuracy.
+- **Diverging choropleth** (Brooklyn price/sqft): the 9-step Spectral ramp
+  `#3288bd → #d53e4f`. Cheap→expensive.
+- **Rule:** brand color lives in chrome, selection outline, slider handle, and
+  chart accents — it must never replace a value on a data scale. Pair color with
+  a selection outline/label so encoding never relies on hue alone (a11y).
+
+### Consistency status
+
+Done (palette + fonts now match the sibling):
+
+- `--background` → `#f0f2f5`, `--foreground` → `#2c333a`,
+  `--muted-foreground` → `#4a5560`, `--accent` → `#749ca8`; added
+  `--primary #5a7684`, `--accent-bold #c17f59`, `--muted`, `--border`, motion tokens.
+- Nav/label sans switched Libre Franklin → **Lato**; JetBrains Mono loaded.
+- Viz `steelblue` literals (`.tract.selected`, `.handle`, `.trend-area`,
+  `.circle-key.blue`, faux-underline hover, `lineColor()` stroke) → `--primary`.
+
+Remaining:
+
+- Generic grays (`#333`, `#555`, `#999`, `#f2f2f2`, `color: black`) in the intro/
+  author chrome → reconcile to `--foreground` / `--muted-foreground` / `--border`.
+- Body `font-size` is still `20px` → move to the sibling's 18px fluid scale.
+- Fixed-width map apps (`1054px`) need a responsive strategy for mobile.
+- Optional: adopt the sibling's `.bm-noise` paper-grain overlay.
+
+## Typography
+
+- **Serif — EB Garamond** (already in use): every heading, editorial body, post
+  titles, blockquotes, map headings. The editorial voice.
+- **Sans — Lato 400/700**: nav, meta, labels, buttons, axis/legend chrome.
+  **Vislet currently uses Libre Franklin here — switch to Lato** to match the
+  sibling. (`--font-heading` / `--font-sans` should resolve to Lato.)
+- **Mono — JetBrains Mono** (Consolas/Monaco fallback): technical chrome, telemetry,
+  code. Not currently loaded in vislet — add it.
+- **Base size:** 18px (`1.125rem`). Vislet's body is currently `20px` — bring to the
+  sibling's fluid scale.
+- **Fluid scale:** `clamp()`-based `--font-size-sm … --font-size-4xl` (see sibling
+  `colors_and_type.css`). Adopt verbatim so type scales without media queries.
+- **Line height:** 1.7 body, 1.8 long-form, 1.3 headings.
+- **Casing:** Title Case for titles; UPPERCASE + `letter-spacing: 0.15em` for
+  section labels/eyebrows used _sparingly_ (vislet's nav/labels already do this);
+  sentence case for nav/body. Buttons title case.
+- **Measure:** reading column capped at **680px**; `max-width: 65ch` on prose
+  paragraphs. Homepage/two-column at 960px.
+
+## Spacing & Layout
+
+- Editorial reading column: **680px** centered (home prose, markdown-text).
+- Map apps: the legacy fixed `1054px` / `500px+541px` side-by-side grid is a
+  **functional** layout (SVG dimensions); keep its proportions but center within
+  the slate page and let the chrome (headings, labels, links) adopt the system.
+- Paragraph spacing `1.5em`; section padding generous.
+- Mobile: collapse to single column ≤768px; the fixed-width map apps need an
+  explicit responsive strategy (scroll-container or scaled SVG) — tracked as a bug.
+
+## Motion
+
+Small, principled set (from the sibling):
+
+- `--transition-fast: 150ms` (color/focus), `--transition-normal: 200ms`
+  (hover/state), `--transition-slow: 300ms` (transform).
+- `--ease-out: cubic-bezier(0.33, 1, 0.68, 1)` (quart-out) — the only curve.
+- No bounce/spring/slide. Hover fades color. Viz transitions (filter, selection,
+  slider) animate to aid comprehension, nothing decorative.
+- Everything wrapped in `@media (prefers-reduced-motion: reduce)`
+  (`transition-duration: 0.01ms !important`).
+
+## Borders, Radii, Shadow, Texture
+
+- **Borders:** hairline 1px `--border`. Section/heading underlines are hairlines.
+  No side-stripe accent borders.
+- **Radii:** `--radius 4px` default; cards `8px`; pills `9999px` only where earned.
+- **Shadows:** effectively none. Depth from hairlines + whitespace + optional noise.
+- **Texture:** optional fixed full-viewport SVG fractal-noise overlay at
+  `opacity: 0.025` (the sibling's `.bm-noise`). Adopt for visual parity if it reads
+  well behind the SVGs; skip if it muddies the data.
+
+## Links & Hover
+
+- Links: color shifts to `--accent`; underline (vislet's faux-underline or a
+  60%→100% accent border) strengthens on hover. Replace the `steelblue` hover with
+  `--primary` / `--accent`.
+- No press states beyond color. No shrink, no shadow.
+
+## Accessibility
+
+WCAG 2.1 AA. Body/label text ≥4.5:1 against **Cool Mist `#f0f2f5`** (re-verify all
+grays after the bg change — gray-on-white that passed may fail on the tinted bg).
+Visible focus rings. Choropleth encoding paired with outline/label, never hue-only.
+Respect `prefers-reduced-motion`.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,70 @@
+# Product
+
+## Register
+
+brand
+
+## Users
+
+Curious readers and Brennan's engineering/design peers who arrive to explore a
+small collection of interactive D3 visualizations about US cities (Brooklyn
+property sales, NYC 311, Chicago crime, North Carolina districts). They are
+reading and poking at data on their own time, not transacting. Most arrive from
+the homepage or a deep link shared by someone else; many are on the sibling site
+www.zamiang.com and follow a link here. The page's job is to invite exploration
+and leave an impression of craft and substance.
+
+## Product Purpose
+
+Vislet (vislet.com) is a static showcase of hand-built interactive data
+visualizations. It is a sibling property to Brennan's personal site
+(zamiang-dot-com-v2) and should read as the same author's work. Success looks
+like a visitor understanding a city's data through direct manipulation (sliders,
+map selection, linked charts) and coming away with the same warm, considered
+sense of craft the homepage conveys. The visualizations are the product; the
+chrome frames them.
+
+## Brand Personality
+
+**Voice**: Direct, warm, unhurried. Lets the data and the interaction speak
+rather than narrating. **Tone**: Editorial and substantive — quiet confidence,
+no salesmanship. **Three words**: Thoughtful, Builder, Curious (shared with the
+sibling site). Warmth is carried by the copper accent, serif editorial type, and
+generous whitespace against a cool slate palette — never by decoration.
+
+## Anti-references
+
+- **Generic SaaS / analytics dashboard.** Card grids, gradient hero-metric
+  blocks, navy-and-teal chrome, identical icon cards. The viz pages are tools but
+  must not read as a BI product.
+- **Trendy AI-slop landing.** Cream/sand body bg, tiny uppercase tracked eyebrows
+  above every section, glassmorphism, numbered `01 / 02` section markers.
+- **Sterile Material / Bootstrap defaults.** Flat component-library look with no
+  editorial voice or typographic character.
+- **Over-animated showcase.** Scroll-jacking, parallax, motion that competes with
+  the data. Motion serves comprehension (transitions on filter/selection), nothing
+  more.
+
+## Design Principles
+
+1. **One author, two sites.** Vislet must look like it was made by whoever made
+   zamiang.com. Inherit the Slate Executive palette, the EB Garamond + Lato +
+   JetBrains Mono voice, and the editorial restraint. See DESIGN.md.
+2. **D3 owns the math, React owns the DOM.** Design decisions render as JSX, never
+   imperative D3 DOM mutation. (Mirrors the migration's core engineering rule.)
+3. **Data legibility is sacred.** Choropleth/sequential color ramps exist to encode
+   data accurately; brand color never overrides a data scale. Brand color lives in
+   chrome, selection, and accent — not in the encoding.
+4. **Parity is the floor, not the ceiling.** Don't break legacy URLs, deep-link
+   states, or data; within those constraints, raise type, spacing, and color to the
+   sibling's standard rather than cloning the 2015 look.
+5. **Content breathes.** Generous whitespace, constrained reading columns, clear
+   sections — the homepage and prose carry the sibling's 600px editorial column.
+
+## Accessibility & Inclusion
+
+WCAG 2.1 AA. Light mode only by design. Respect `prefers-reduced-motion` (collapse
+transitions to near-instant). Semantic markup, visible focus indicators, body and
+label text held to ≥4.5:1 contrast against their actual background (the Cool Mist
+`#f0f2f5` surface, not white). Choropleth ramps must stay distinguishable; pair
+color with selection outline/label so encoding never relies on hue alone.

--- a/__tests__/lib/line-chart.test.ts
+++ b/__tests__/lib/line-chart.test.ts
@@ -67,7 +67,7 @@ describe('lineColor', () => {
   it('maps mean / compare / default series to their colors', () => {
     expect(lineColor('price-mean')).toBe('lightgray');
     expect(lineColor('compare-dataset')).toBe('#D53F50');
-    expect(lineColor('park-slope')).toBe('steelblue');
+    expect(lineColor('park-slope')).toBe('#5a7684'); // Steel Blue (--primary)
   });
 });
 

--- a/__tests__/lib/slider.test.ts
+++ b/__tests__/lib/slider.test.ts
@@ -22,9 +22,13 @@ describe('snapToNearest', () => {
 });
 
 describe('getYearTickCount', () => {
-  it('returns 4 ticks per year of span', () => {
-    expect(getYearTickCount(dates)).toBe(12); // 2013 - 2010 = 3 years * 4
+  it('returns ~1 tick per year of span by default (readable labels)', () => {
+    expect(getYearTickCount(dates)).toBe(3); // 2013 - 2010 = 3 years * 1
     expect(getYearTickCount(dates, 2)).toBe(6);
+  });
+
+  it('floors at 2 ticks so short spans still render an axis', () => {
+    expect(getYearTickCount([Y(2012), Y(2013)])).toBe(2); // 1-year span -> max(1, 2)
   });
 
   it('returns 0 for empty input', () => {

--- a/src/components/SvgMap.tsx
+++ b/src/components/SvgMap.tsx
@@ -177,6 +177,21 @@ export function SvgMap({
   return (
     <div className={wrapperClass}>
       <svg width={width} height={height}>
+        {/* Hatch fill for inert "park" areas — referenced by `.tract.park`
+            (`fill: url(#hatch)` in globals.css). Without this defs the paint
+            reference fails and parks render as solid black. */}
+        <defs>
+          <pattern
+            id="hatch"
+            patternUnits="userSpaceOnUse"
+            width={6}
+            height={6}
+            patternTransform="rotate(45)"
+          >
+            <rect width={6} height={6} fill="var(--muted, #e8eaed)" />
+            <line x1={0} y1={0} x2={0} y2={6} stroke="#c2c9d1" strokeWidth={1.5} />
+          </pattern>
+        </defs>
         <g
           transform={zoomTransform}
           style={{ transition: 'transform 0.5s', strokeWidth: zoomTransform ? 0.5 : 1 }}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -45,7 +45,7 @@ const canonical = Astro.url.href;
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,700;1,400&family=Libre+Franklin:wght@400;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400..800;1,400..800&family=JetBrains+Mono:wght@400;700&family=Lato:wght@400;700&display=swap"
       rel="stylesheet"
     />
 

--- a/src/lib/line-chart.ts
+++ b/src/lib/line-chart.ts
@@ -70,7 +70,7 @@ export function getLines(
 export function lineColor(name: string): string {
   if (name.includes(MEAN_SUFFIX)) return 'lightgray';
   if (name.includes('compare-')) return '#D53F50';
-  return 'steelblue';
+  return '#5a7684'; // Steel Blue (--primary) — shared Slate Executive palette
 }
 
 /** `[min, max]` value extent across all series (skips empty series). Mirrors the y-domain. */

--- a/src/lib/slider.ts
+++ b/src/lib/slider.ts
@@ -26,13 +26,15 @@ export function snapToNearest(dates: number[], x0: number): number {
 }
 
 /**
- * Number of axis ticks: 4 per year across the date span. Mirrors the *intent*
- * of legacy `getNumberTicks` (whose `getFullYear(arg)` call was a no-op bug that
- * effectively used the current year).
+ * Number of axis ticks across the date span. The `Axis` component renders a
+ * label on every tick (no auto-thinning), so this must stay sparse enough to
+ * read: ~one tick per year. The legacy `getNumberTicks` asked for 4/year, but
+ * that produced ~44 ticks over a 11-year span and an unreadable smear of
+ * overlapping labels. One per year lets D3 snap to clean yearly gridlines.
  */
-export function getYearTickCount(dates: number[], ticksPerYear = 4): number {
+export function getYearTickCount(dates: number[], ticksPerYear = 1): number {
   if (dates.length === 0) return 0;
   const firstYear = new Date(dates[0]).getFullYear();
   const lastYear = new Date(dates[dates.length - 1]).getFullYear();
-  return (lastYear - firstYear) * ticksPerYear;
+  return Math.max((lastYear - firstYear) * ticksPerYear, 2);
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -8,20 +8,37 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-muted-foreground: var(--muted-foreground);
+  --color-primary: var(--primary);
   --color-accent: var(--accent);
-  /* EB Garamond ≈ Adobe Garamond Pro (legacy body); Libre Franklin ≈ Franklin Gothic URW (legacy nav/labels) */
-  --font-body: 'EB Garamond', Georgia, Cambria, 'Times New Roman', Times, serif;
-  --font-heading: 'Libre Franklin', 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;
+  --color-accent-bold: var(--accent-bold);
+  --color-border: var(--border);
+  --color-muted: var(--muted);
+  /* Shared "Slate Executive" voice with zamiang-dot-com-v2: EB Garamond (serif,
+     editorial body + titles), Lato (sans, nav/labels/meta), JetBrains Mono (chrome). */
+  --font-body: 'EB Garamond', 'Iowan Old Style', 'Palatino Linotype', Georgia, serif;
+  --font-heading: 'Lato', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
   --font-sans: var(--font-heading);
   --font-serif: var(--font-body);
 }
 
 :root {
   color-scheme: light;
-  --background: #ffffff;
-  --foreground: #1a1a1a;
-  --muted-foreground: #6b6b6b;
-  --accent: #2b6cb0;
+  /* Slate Executive palette — kept in sync with zamiang-dot-com-v2 (DESIGN.md). */
+  --background: #f0f2f5; /* Cool Mist — never pure white */
+  --foreground: #2c333a; /* Deep Charcoal Blue */
+  --primary: #5a7684; /* Steel Blue — chrome, viz selection/handle */
+  --accent: #749ca8; /* Dusty Teal — links, labels, accents */
+  --accent-bold: #c17f59; /* Warm Copper — the only warm color */
+  --muted: #e8eaed;
+  --muted-foreground: #4a5560; /* AA on Cool Mist */
+  --border: #d1d5db;
+
+  /* Motion — quart-out, the only curve (shared system). */
+  --transition-fast: 150ms;
+  --transition-normal: 200ms;
+  --transition-slow: 300ms;
+  --ease-out: cubic-bezier(0.33, 1, 0.68, 1);
 }
 
 html {
@@ -36,7 +53,7 @@ body {
   line-height: 1.6em;
   letter-spacing: 0.01rem;
   font-weight: 400;
-  color: rgba(0, 0, 0, 0.8);
+  color: var(--foreground);
 }
 
 /* Faux-underline affordance — ported from components/layout/stylesheets */
@@ -64,7 +81,7 @@ body {
 .faux-underline-large:hover::before,
 .faux-underline-hover:hover::before,
 .faux-underline-hover.active::before {
-  border-color: steelblue;
+  border-color: var(--primary);
 }
 
 /* ---- vislet-intro header ---- */
@@ -173,14 +190,16 @@ body {
   cursor: pointer;
 }
 .tract.selected {
-  fill: steelblue;
-  stroke: #333;
+  fill: var(--primary);
+  stroke: var(--foreground);
   stroke-width: 1.5px;
 }
 .tract.dimmed {
   opacity: 0.25;
 }
-.tract.park {
+/* Parks/inert areas carry only the `park` class (SvgMap `shapeClass`), not
+   `tract park` — target `.park` directly so the hatch fill actually applies. */
+.park {
   fill: url(#hatch);
   cursor: default;
 }
@@ -244,9 +263,104 @@ body {
   fill: #d53e4f;
 }
 
+/* ==========================================================================
+   Linear choropleth color key (ColorKey.tsx → `.linear-graph-key`).
+   The legacy Stylus rules were never ported, so the swatch row had no styles
+   and the `.color0–8` classes only set SVG `fill` (not `background`): the key
+   rendered as bare numbers stacked at the left edge with no color. Restore the
+   horizontal swatch strip + breakpoint values here.
+   ========================================================================== */
+.linear-graph-key {
+  margin-top: 10px;
+}
+.key-bars {
+  display: flex;
+  flex-direction: row;
+}
+.key-bar {
+  height: 10px;
+}
+.key-bar-values {
+  display: flex;
+  flex-direction: row;
+  margin-top: 4px;
+}
+.key-bar-value {
+  font-size: 11px;
+  font-family: var(--font-heading);
+  color: var(--muted-foreground);
+  text-align: center;
+}
+.key-label {
+  margin-top: 6px;
+  font-size: 0.75rem;
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--muted-foreground);
+}
+
+/* Swatch backgrounds — Reds ramp (default: crime/311). Mirrors `.tract.colorN`. */
+.key-bar.color0 {
+  background: #fee5d9;
+}
+.key-bar.color1 {
+  background: #fcbba1;
+}
+.key-bar.color2 {
+  background: #fc9272;
+}
+.key-bar.color3 {
+  background: #fb6a4a;
+}
+.key-bar.color4 {
+  background: #ef3b2c;
+}
+.key-bar.color5 {
+  background: #cb181d;
+}
+.key-bar.color6 {
+  background: #a50f15;
+}
+.key-bar.color7 {
+  background: #67000d;
+}
+.key-bar.color8 {
+  background: #40000a;
+}
+
+/* Swatch backgrounds — Spectral ramp (Brooklyn price/sqft). */
+.spectral-map .key-bar.color0 {
+  background: #3288bd;
+}
+.spectral-map .key-bar.color1 {
+  background: #66c2a5;
+}
+.spectral-map .key-bar.color2 {
+  background: #abdda4;
+}
+.spectral-map .key-bar.color3 {
+  background: #e6f598;
+}
+.spectral-map .key-bar.color4 {
+  background: #ffffbf;
+}
+.spectral-map .key-bar.color5 {
+  background: #fee08b;
+}
+.spectral-map .key-bar.color6 {
+  background: #fdae61;
+}
+.spectral-map .key-bar.color7 {
+  background: #f46d43;
+}
+.spectral-map .key-bar.color8 {
+  background: #d53e4f;
+}
+
 /* Date slider handle */
 .handle {
-  fill: steelblue;
+  fill: var(--primary);
   stroke: #fff;
   stroke-width: 1.5px;
   cursor: ew-resize;
@@ -267,7 +381,7 @@ body {
   stroke-width: 1.5px;
 }
 .trend-area {
-  fill: steelblue;
+  fill: var(--primary);
   opacity: 0.15;
 }
 
@@ -369,7 +483,7 @@ body {
   margin-right: 4px;
 }
 .circle-key.blue {
-  background: steelblue;
+  background: var(--primary);
 }
 .circle-key.red {
   background: #d53f50;


### PR DESCRIPTION
## Goal
Make vislet **visually consistent with the sibling site `zamiang-dot-com-v2`** and **fix UI bugs**. Vislet was on plain white + a one-off blue + Libre Franklin; it now inherits the sibling's "Slate Executive" system, and three rendering bugs found while verifying it are fixed.

## Visual consistency
`src/styles/globals.css` + `src/layouts/BaseLayout.astro`:

| | Before | After |
|---|---|---|
| Background | `#ffffff` | `#f0f2f5` Cool Mist |
| Ink | `#1a1a1a` | `#2c333a` Deep Charcoal Blue |
| Accent | `#2b6cb0` | `#749ca8` Dusty Teal (+ `--primary` Steel Blue, `--accent-bold` Copper) |
| Sans | Libre Franklin | **Lato** |
| Mono | none | **JetBrains Mono** |

Viz chrome (`.tract.selected`, slider handle, trend area, line strokes, link hover) remapped from the `steelblue` keyword to `--primary`. Data-encoding ramps (Reds/Spectral) left intact — brand color never overrides an encoding.

## Bug fixes
1. **Parks rendered as solid black blobs.** `#hatch` was referenced but never defined, *and* the CSS targeted `.tract.park` while `SvgMap` emits only `.park`. Added the `<pattern>` and fixed the selector → subtle slate hatch.
2. **Date-slider labels were an unreadable smear.** `getYearTickCount` asked for 4 ticks/year (~44 labels over 2003–2014) and `Axis` labels every tick. Reduced to ~1/year → clean yearly labels.
3. **Choropleth color key was invisible.** The `.linear-graph-key` / `.key-bar` styles were never ported and `.color0–8` only set SVG `fill`, not `background`. Legend was bare numbers jammed at the left edge. Added the swatch-strip CSS for both ramps.

## Docs
Adds `PRODUCT.md` + `DESIGN.md` documenting the inherited Slate Executive system and a consistency status (done vs. remaining: chrome grays, 18px fluid type, map-app mobile responsiveness, optional noise overlay).

## Verification
- All four viz pages + home checked in-browser (1440px): consistent Cool Mist bg, no console errors.
- Unit tests updated; **87/87 pass**. `tsc` clean on touched files (pre-existing `@playwright/test` resolution errors are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)