### PR TITLE
ci: add Claude Code review + @claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,68 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.astro"
+
+jobs:
+  claude-review:
+    # Only review PRs from collaborators. A fork PR from a random user must not
+    # be able to spin up Claude on our account.
+    if: |
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request against the guidance in CLAUDE.md,
+            docs/MIGRATION.md, and docs/ARCHITECTURE.md. This repo is mid-migration
+            from a 2015-era Ezel/Backbone/CoffeeScript/D3-v3 stack to Astro 6 +
+            React 19 islands + TypeScript + D3 v7. Prioritize, in order:
+            1. Correctness bugs (D3 v3→v7 symbol mapping, Astro island hydration,
+               TypeScript errors, dropped promises). Flag any new features added to
+               the legacy stack — only migration is allowed.
+            2. The "D3 owns the math, React owns the DOM" rule: never let
+               `d3.select(...).append(...)` mutate nodes React also manages.
+            3. URL/compatibility contract — `/`, `/brooklyn`, `/311`, `/chicago`,
+               `/north-carolina` and legacy graph-key deep-link/query states must
+               keep resolving (CLAUDE.md §3, MIGRATION.md §3).
+            4. Security: secrets handling (never re-add the leaked AWS keys), env
+               var leaks, deploy-key scope.
+            5. Data handling — data is fetched from `public/data/<app>/`, not
+               bundled; the 12 MB `bbl-to-lat-long.json` must stay pre-joined.
+            6. Test coverage for new behavior (Vitest for pure math, Playwright smoke).
+
+            Skip stylistic nits already covered by ESLint, Prettier, or Tailwind.
+            Prefix preferential feedback with "(nit)". Post one consolidated review.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,49 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'


### PR DESCRIPTION
Sets up automated PR review with Claude, mirroring `~/zamiang-dot-com-v2`.

## What this adds
- **`.github/workflows/claude-code-review.yml`** — runs on every PR `opened`/`synchronize`, gated to OWNER/MEMBER/COLLABORATOR authors (fork PRs from randoms can't spin up Claude on our account). The review prompt is tailored to Vislet's CLAUDE.md priorities:
  - D3 v3→v7 symbol-mapping correctness; flag new features added to the legacy stack
  - the "D3 owns the math, React owns the DOM" rule
  - the URL/deep-link compatibility contract
  - secret hygiene (never re-add the leaked AWS keys)
  - data-fetch convention (`public/data/<app>/`, pre-joined `bbl-to-lat-long.json`)
  - Vitest/Playwright coverage
- **`.github/workflows/claude.yml`** — responds to `@claude` mentions in issues, PR comments, and reviews.

## ⚠️ Required before this works
The **`CLAUDE_CODE_OAUTH_TOKEN`** repo secret must be set on `zamiang/vislet` (it's not currently present). Generate with `claude setup-token` and add via:

```
gh secret set CLAUDE_CODE_OAUTH_TOKEN
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)