### PR TITLE
Deepen visual parity with zamiang-dot-com-v2 (typography + layout)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -44,34 +44,42 @@ from shadows or gradients.
 
 ### Consistency status
 
-Done (palette + fonts now match the sibling):
+Done — palette, fonts, type scale, and layout chrome now match the sibling:
 
-- `--background` → `#f0f2f5`, `--foreground` → `#2c333a`,
-  `--muted-foreground` → `#4a5560`, `--accent` → `#749ca8`; added
-  `--primary #5a7684`, `--accent-bold #c17f59`, `--muted`, `--border`, motion tokens.
-- Nav/label sans switched Libre Franklin → **Lato**; JetBrains Mono loaded.
-- Viz `steelblue` literals (`.tract.selected`, `.handle`, `.trend-area`,
-  `.circle-key.blue`, faux-underline hover, `lineColor()` stroke) → `--primary`.
+- Palette: `--background #f0f2f5`, `--foreground #2c333a`, `--muted-foreground
+#4a5560`, `--accent #749ca8`, `--primary #5a7684`, `--accent-bold #c17f59`,
+  plus `--secondary`, `--primary-foreground`, `--accent-foreground`, `--card`,
+  `--border`, `--muted`, motion tokens.
+- **Reading voice flipped to match the sibling:** body/prose is **Lato (sans)**;
+  **EB Garamond (serif)** is reserved for headings + editorial titles (`h1–h6`,
+  `.project .title`, `#home .heading`, `.author .name`, `.map-app .heading`,
+  `.markdown-text` headings). JetBrains Mono loaded for chrome.
+- Fluid `clamp()` type scale (`--font-size-sm … 4xl`) adopted verbatim; body
+  base `20px → 18px` (`--font-size`), line-height aligned (1.5 body / 1.7 prose).
+- Signature **paper-grain noise overlay** (`body::after`, opacity 0.025) added.
+- Dark `.border` bars (`30px × 2px #333`) → **4rem hairline rules** (`1px
+--border`), matching the sibling's `.center-divider`.
+- Uppercase section labels ("Featured Projects", "Created By") → **teal
+  `--accent`** with `--tracking-caps`, echoing `.section-label`.
+- Link hover color `--primary → --accent` (teal), matching the sibling.
+- Intro/author chrome grays (`#333/#555/#666/#f2f2f2/black`) reconciled to tokens.
+- Viz `steelblue` literals → `--primary` (prior pass).
 
 Remaining:
 
-- Generic grays (`#333`, `#555`, `#999`, `#f2f2f2`, `color: black`) in the intro/
-  author chrome → reconcile to `--foreground` / `--muted-foreground` / `--border`.
-- Body `font-size` is still `20px` → move to the sibling's 18px fluid scale.
-- Fixed-width map apps (`1054px`) need a responsive strategy for mobile.
-- Optional: adopt the sibling's `.bm-noise` paper-grain overlay.
+- Fixed-width map apps (`1054px`) still need a responsive strategy for mobile.
+- Optional: section-tint full-bleed wrappers + the sibling's `FloatingParticles`.
 
 ## Typography
 
-- **Serif — EB Garamond** (already in use): every heading, editorial body, post
-  titles, blockquotes, map headings. The editorial voice.
-- **Sans — Lato 400/700**: nav, meta, labels, buttons, axis/legend chrome.
-  **Vislet currently uses Libre Franklin here — switch to Lato** to match the
-  sibling. (`--font-heading` / `--font-sans` should resolve to Lato.)
-- **Mono — JetBrains Mono** (Consolas/Monaco fallback): technical chrome, telemetry,
-  code. Not currently loaded in vislet — add it.
-- **Base size:** 18px (`1.125rem`). Vislet's body is currently `20px` — bring to the
-  sibling's fluid scale.
+- **Serif — EB Garamond**: headings and editorial titles only (`h1–h6`, project
+  titles, the author name, map headings, blockquote-adjacent headings). The
+  editorial voice. Opt in via `--font-serif`.
+- **Sans — Lato 400/700**: the default — body/prose, nav, meta, labels, buttons,
+  axis/legend chrome. `--font-sans` is the document default; `--font-body` /
+  `--font-heading` are aliases that resolve to it.
+- **Mono — JetBrains Mono** (Consolas/Monaco fallback): technical chrome, code.
+- **Base size:** 18px (`--font-size`), on the fluid `clamp()` scale.
 - **Fluid scale:** `clamp()`-based `--font-size-sm … --font-size-4xl` (see sibling
   `colors_and_type.css`). Adopt verbatim so type scales without media queries.
 - **Line height:** 1.7 body, 1.8 long-form, 1.3 headings.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -68,7 +68,10 @@ Done — palette, fonts, type scale, and layout chrome now match the sibling:
 Remaining:
 
 - Fixed-width map apps (`1054px`) still need a responsive strategy for mobile.
-- Optional: section-tint full-bleed wrappers + the sibling's `FloatingParticles`.
+- Optional: section-tint full-bleed wrappers.
+
+Intentionally **not** adopted from the sibling: the `FloatingParticles` background
+(decorative; would compete with the data visualizations).
 
 ## Typography
 

--- a/README.md
+++ b/README.md
@@ -7,53 +7,102 @@ Chicago crime, North Carolina districts), historically hosted at
 
 ## Status
 
-The site currently runs on a **2015-era stack** (Ezel/Backbone + CoffeeScript +
-Jade + Stylus + Gulp + Browserify + **D3 v3**, deployed static to S3) and is being
-**migrated to a modern stack**: **Astro + React + TypeScript + D3 v7 + Tailwind,
-hosted on Cloudflare Pages** — matching the setup of
-[zamiang.com](https://github.com/zamiang/homepage-notion-nextjs).
+The site is **mid-migration** from a **2015-era stack** (Ezel/Backbone +
+CoffeeScript + Jade + Stylus + Gulp + Browserify + **D3 v3**, deployed static to
+S3) to a modern one: **Astro + React + TypeScript + D3 v7 + Tailwind v4**, hosted
+on **Cloudflare Pages** — matching the setup of
+[zamiang.com](https://github.com/zamiang/zamiang-dot-com-v2).
 
-📄 **Documentation:**
-- [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) — how the current site is built.
-- [`docs/MIGRATION.md`](./docs/MIGRATION.md) — the modernization plan (stack,
-  phased page-by-page strategy, D3 v3→v7 mapping, effort estimate).
-
-> ⚠️ **Security:** an `airflow/.env` file (now deleted) previously contained live
-> AWS keys. They are being revoked — see the security note in `ARCHITECTURE.md`.
+The migration follows a strangler-fig approach: the new Astro app stands beside
+the legacy tree, and all pages (`/`, `/brooklyn`, `/311`, `/chicago`,
+`/north-carolina`) now render on the new stack. The legacy 2015 toolchain
+remains in-tree until it is fully retired.
 
 ## Visualizations
 
-| Page | What it shows |
-|------|---------------|
-| `/` (home) | Landing page / project index |
-| `/brooklyn` | 322,056 Brooklyn property sales, 2003–2014 |
-| `/311` | 7.7M NYC 311 calls distributed across the city, 2010–2014 |
-| `/chicago` | 5.7M Chicago crimes across the city, 2003–2014 |
-| `/north-carolina` | Congressional district / gerrymandering analysis |
+| Page              | What it shows                                             |
+| ----------------- | --------------------------------------------------------- |
+| `/` (home)        | Landing page / project index                              |
+| `/brooklyn`       | 322,056 Brooklyn property sales, 2003–2014                |
+| `/311`            | 7.7M NYC 311 calls distributed across the city, 2010–2014 |
+| `/chicago`        | 5.7M Chicago crimes across the city, 2003–2014            |
+| `/north-carolina` | Congressional district / gerrymandering analysis          |
 
-## Legacy development workflow (current stack)
+## Development
 
-> This is the existing Gulp/Ezel workflow. It will be replaced by the standard
-> Astro `npm run dev` / `npm run build` flow as the migration lands — see
-> `docs/MIGRATION.md`.
+Node version is pinned in [`.nvmrc`](./.nvmrc) (Node 24). The site is a standard
+Astro app:
+
+```sh
+npm install
+npm run dev        # local dev server (http://localhost:4321)
+npm run build      # production build → dist/
+npm run preview    # serve the production build locally
+```
+
+Quality gates (CI runs these on every PR):
+
+```sh
+npm run typecheck  # tsc --noEmit
+npm run lint       # eslint (.ts/.tsx/.astro), zero warnings
+npm test           # vitest unit tests
+npm run test:e2e   # playwright smoke tests
+npm run knip       # unused files/exports/deps
+```
+
+Data is fetched at runtime, not bundled. The source datasets are rebuilt from the
+ETL scripts under `scripts/etl/` into `public/data/<app>/`:
+
+```sh
+npm run data:build              # all apps
+npm run data:build:brooklyn     # one app
+```
+
+## Design
+
+Vislet shares the **"Slate Executive"** design system with its sibling site
+[zamiang-dot-com-v2](https://github.com/zamiang/zamiang-dot-com-v2): a cool slate
+palette on a Cool Mist background, EB Garamond (serif) headings over Lato (sans)
+body, hairline rules, and a subtle paper-grain texture. The canonical tokens live
+in `src/styles/globals.css` (`:root`).
+
+- [`PRODUCT.md`](./PRODUCT.md) — who the site is for, brand personality, design principles.
+- [`DESIGN.md`](./DESIGN.md) — the visual system (color, typography, layout, motion).
+
+## Deployment
+
+Hosted on **Cloudflare Pages** via Git integration (config in
+[`wrangler.toml`](./wrangler.toml)):
+
+- **Build command:** `npm run build` (`astro build` → `dist/`)
+- **Output directory:** `dist`
+- **Production branch:** `main` (PRs get automatic preview deploys)
+
+Manual deploys use `npx wrangler pages deploy dist` (not `wrangler deploy`, which
+is Workers-mode).
+
+## Documentation
+
+- [`CLAUDE.md`](./CLAUDE.md) — orientation for agents: conventions, Git/PR workflow.
+- [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) — how the (legacy) site is built.
+- [`docs/MIGRATION.md`](./docs/MIGRATION.md) — the phased modernization plan and
+  the D3 v3→v7 mapping.
+
+> ⚠️ **Security:** an `airflow/.env` file (now deleted) previously contained live
+> AWS keys. They are being revoked — see the security note in `CLAUDE.md`.
+
+## Legacy workflow (being retired)
+
+The original Gulp/Ezel toolchain still lives in the repo and stays deployable
+until the last page lands on the new stack. It is no longer the primary workflow;
+prefer the Astro commands above.
 
 ```sh
 npm install -g gulp
 npm install
 gulp server      # serve ./dist
-gulp watch       # recompile coffee/stylus/jade on change (in a second tab)
+gulp watch       # recompile coffee/stylus/jade on change (second tab)
 ```
 
-- `./dist` — development build output
-- `./public` — production build output (hashed, gzipped)
-
-### Deploying (legacy)
-
-Create a gitignored `aws.json`:
-
-```json
-{ "key": "…", "secret": "…", "bucket": "www.url.com", "region": "us-east-1" }
-```
-
-`gulp deploy` compiles assets, hashes + rewrites references, uglifies/gzips, and
-uploads HTML/JS/CSS/images to the S3 bucket.
+Legacy deploys read a gitignored `aws.json` (`{ "key", "secret", "bucket",
+"region" }`) and run `gulp deploy` to push hashed/gzipped assets to S3.

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,19 +7,23 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
   --color-primary: var(--primary);
+  --color-secondary: var(--secondary);
   --color-accent: var(--accent);
   --color-accent-bold: var(--accent-bold);
   --color-border: var(--border);
-  --color-muted: var(--muted);
-  /* Shared "Slate Executive" voice with zamiang-dot-com-v2: EB Garamond (serif,
-     editorial body + titles), Lato (sans, nav/labels/meta), JetBrains Mono (chrome). */
-  --font-body: 'EB Garamond', 'Iowan Old Style', 'Palatino Linotype', Georgia, serif;
-  --font-heading: 'Lato', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  /* Shared "Slate Executive" type voice with zamiang-dot-com-v2: Lato (sans)
+     carries body + UI + labels; EB Garamond (serif) is reserved for headings
+     and editorial titles; JetBrains Mono for technical chrome. */
+  --font-serif: 'EB Garamond', 'Iowan Old Style', 'Palatino Linotype', Georgia, serif;
+  --font-sans: 'Lato', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-  --font-sans: var(--font-heading);
-  --font-serif: var(--font-body);
+  /* Legacy aliases — both now resolve to the sans body voice; serif is opt-in
+     on specific editorial titles via `--font-serif`. */
+  --font-body: var(--font-sans);
+  --font-heading: var(--font-sans);
 }
 
 :root {
@@ -28,17 +32,46 @@
   --background: #f0f2f5; /* Cool Mist — never pure white */
   --foreground: #2c333a; /* Deep Charcoal Blue */
   --primary: #5a7684; /* Steel Blue — chrome, viz selection/handle */
+  --primary-foreground: #f0f2f5;
+  --secondary: #e3e7eb; /* Lighter mist for secondary surfaces */
   --accent: #749ca8; /* Dusty Teal — links, labels, accents */
+  --accent-foreground: #2c333a;
   --accent-bold: #c17f59; /* Warm Copper — the only warm color */
+  --accent-bold-hover: #d4906a;
   --muted: #e8eaed;
   --muted-foreground: #4a5560; /* AA on Cool Mist */
   --border: #d1d5db;
+  --card: #ffffff;
+
+  /* Fluid type scale (clamp-based) — adopted verbatim from the sibling. */
+  --font-size: 1.125rem; /* 18px base */
+  --font-size-sm: clamp(0.875rem, 0.85rem + 0.1vw, 0.9375rem);
+  --font-size-base: clamp(1rem, 0.95rem + 0.2vw, 1.125rem);
+  --font-size-lg: clamp(1.125rem, 1rem + 0.4vw, 1.25rem);
+  --font-size-xl: clamp(1.25rem, 1.1rem + 0.5vw, 1.5rem);
+  --font-size-2xl: clamp(1.5rem, 1.25rem + 0.8vw, 1.875rem);
+  --font-size-3xl: clamp(1.875rem, 1.5rem + 1.2vw, 2.5rem);
+  --font-size-4xl: clamp(2.25rem, 1.75rem + 1.5vw, 3rem);
+
+  /* Reading rhythm. */
+  --paragraph-spacing: 1.5em;
+  --line-height-body: 1.7;
+  --line-height-relaxed: 1.8;
+  --line-height-tight: 1.3;
+  --tracking-caps: 0.15em;
+  --article-max-width: 600px;
 
   /* Motion — quart-out, the only curve (shared system). */
   --transition-fast: 150ms;
   --transition-normal: 200ms;
   --transition-slow: 300ms;
   --ease-out: cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 html {
@@ -48,12 +81,53 @@ html {
 
 body {
   margin: 0;
-  font-family: var(--font-body);
-  font-size: 20px;
-  line-height: 1.6em;
-  letter-spacing: 0.01rem;
+  font-family: var(--font-sans);
+  font-size: var(--font-size);
+  line-height: 1.5;
   font-weight: 400;
   color: var(--foreground);
+}
+
+/* Editorial headings — EB Garamond serif, matching the sibling. Vislet's own
+   heading classes opt in to `--font-serif` individually below; this catches
+   any semantic h1–h6 in migrated prose. */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-serif);
+  line-height: var(--line-height-tight);
+  font-weight: 600;
+  text-wrap: balance;
+}
+
+p {
+  line-height: var(--line-height-body);
+}
+
+/* Subtle paper-grain overlay — the sibling's signature texture. Sits above
+   everything but is non-interactive, so map clicks pass straight through. */
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+  opacity: 0.025;
+  pointer-events: none;
+  z-index: 9999;
+}
+
+/* Reduced motion — collapse all transitions/animations (map zoom, slider,
+   link underlines) to near-instant. Matches the sibling's a11y guarantee. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
 }
 
 /* Faux-underline affordance — ported from components/layout/stylesheets */
@@ -76,12 +150,12 @@ body {
   transition: border-color 0.3s;
 }
 .faux-underline-large::before {
-  border-color: #333;
+  border-color: var(--foreground);
 }
 .faux-underline-large:hover::before,
 .faux-underline-hover:hover::before,
 .faux-underline-hover.active::before {
-  border-color: var(--primary);
+  border-color: var(--accent);
 }
 
 /* ---- vislet-intro header ---- */
@@ -92,10 +166,10 @@ body {
   text-align: center;
 }
 .vislet-intro a {
-  color: #555;
+  color: var(--muted-foreground);
 }
 .vislet-intro .title {
-  color: black;
+  color: var(--foreground);
   font-weight: normal;
   letter-spacing: 1px;
   line-height: 141%;
@@ -105,7 +179,7 @@ body {
 }
 .vislet-intro .about {
   margin: 0 auto 3px;
-  font-family: var(--font-body);
+  color: var(--muted-foreground);
 }
 .vislet-intro .items {
   margin-top: 6px;
@@ -117,24 +191,25 @@ body {
   text-transform: uppercase;
   letter-spacing: 2px;
   line-height: 150%;
-  color: rgba(0, 0, 0, 0.8);
+  color: var(--foreground);
 }
 
 /* ---- author / footer bio ---- */
 .author {
-  border-top: 1px solid #f2f2f2;
+  border-top: 1px solid var(--border);
   text-align: center;
-  font-size: 20px;
+  font-size: var(--font-size-base);
   margin: 60px auto 0;
   padding-top: 20px;
 }
 .author .written-by-note {
   font-family: var(--font-heading);
   line-height: 148%;
-  font-weight: normal;
-  letter-spacing: 2px;
+  font-weight: 600;
+  letter-spacing: var(--tracking-caps);
   text-transform: uppercase;
   font-size: 13px;
+  color: var(--accent);
   margin-top: 26px;
   margin-bottom: 10px;
 }
@@ -154,26 +229,25 @@ body {
   border-radius: 50%;
 }
 .author .name {
-  font-size: 28px;
-  font-family: var(--font-heading);
-  letter-spacing: 2px;
+  font-size: var(--font-size-3xl);
+  font-family: var(--font-serif);
+  letter-spacing: -0.01em;
   margin-bottom: 28px;
-  line-height: 148%;
-  font-weight: normal;
-  color: rgba(0, 0, 0, 0.8);
+  line-height: 1.15;
+  font-weight: 600;
+  color: var(--foreground);
 }
 .author .info {
   margin-bottom: 21px;
 }
 .author .call-to-action {
-  font-family: var(--font-body);
   margin: 0 auto;
 }
 .author .border {
-  width: 30px;
-  margin: 16px auto;
-  background: #333;
-  height: 2px;
+  width: 4rem;
+  margin: 24px auto;
+  border-top: 1px solid var(--border);
+  height: 0;
   display: block;
 }
 
@@ -417,16 +491,16 @@ body {
   text-align: center;
 }
 .map-app header .heading {
-  font-size: 1.5rem;
-  font-weight: normal;
-  font-family: var(--font-body);
+  font-size: var(--font-size-2xl);
+  font-weight: 600;
+  font-family: var(--font-serif);
   margin-bottom: 8px;
   text-align: center;
 }
 .map-app header .border {
-  width: 30px;
-  height: 2px;
-  background: #333;
+  width: 4rem;
+  height: 0;
+  border-top: 1px solid var(--border);
   margin: 0 auto 16px;
 }
 
@@ -463,7 +537,7 @@ body {
 }
 .graph-help-text {
   font-size: 0.875rem;
-  color: #666;
+  color: var(--muted-foreground);
   margin-bottom: 12px;
 }
 .graph-heading-container {
@@ -498,31 +572,35 @@ body {
 .markdown-text {
   max-width: 680px;
   margin-top: 48px;
-  line-height: 1.7;
+  line-height: var(--line-height-relaxed);
 }
 .markdown-text h1 {
-  font-size: 1.25rem;
+  font-size: var(--font-size-2xl);
   font-weight: 700;
   margin-bottom: 16px;
 }
 .markdown-text h2 {
-  font-size: 1.1rem;
-  font-weight: 700;
+  font-size: var(--font-size-xl);
+  font-weight: 600;
   margin-top: 24px;
   margin-bottom: 8px;
 }
 .markdown-text p {
-  margin-bottom: 12px;
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-relaxed);
+  max-width: 65ch;
+  margin-bottom: var(--paragraph-spacing);
 }
 .markdown-text img {
   max-width: 100%;
   margin: 16px 0;
 }
 .markdown-text blockquote {
-  border-left: 3px solid #ccc;
-  padding-left: 16px;
-  color: #555;
-  margin: 16px 0;
+  border-left: 4px solid var(--accent);
+  padding-left: 1.5em;
+  color: var(--muted-foreground);
+  font-style: italic;
+  margin: 2em 0;
 }
 
 /* Home page — centered column, legacy: max-width 800px, margin: 0 auto */
@@ -538,18 +616,18 @@ body {
   margin: 0 auto;
 }
 #home .heading {
-  font-size: 36px;
+  font-size: var(--font-size-4xl);
   text-align: center;
-  letter-spacing: 1px;
+  letter-spacing: -0.01em;
   margin-bottom: 16px;
-  line-height: 148%;
-  font-weight: normal;
-  font-family: var(--font-heading);
+  line-height: var(--line-height-tight);
+  font-weight: 700;
+  font-family: var(--font-serif);
 }
 #home .sub-heading {
   text-align: center;
   margin-bottom: 21px;
-  font-family: var(--font-body);
+  color: var(--muted-foreground);
 }
 
 /* Legacy .projects within #home */
@@ -562,14 +640,15 @@ body {
   font-family: var(--font-heading);
   text-transform: uppercase;
   text-align: center;
-  letter-spacing: 2px;
-  font-weight: normal;
-  font-size: 1rem;
+  letter-spacing: var(--tracking-caps);
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  color: var(--accent);
 }
 .projects > .border {
-  width: 30px;
-  height: 2px;
-  background: #333;
+  width: 4rem;
+  height: 0;
+  border-top: 1px solid var(--border);
   margin: 8px auto 30px;
   display: block;
 }
@@ -580,15 +659,16 @@ body {
   color: inherit;
 }
 .project .title {
-  font-size: 26px;
-  line-height: 160%;
-  font-family: var(--font-body);
+  font-size: var(--font-size-2xl);
+  line-height: 1.3;
+  font-weight: 600;
+  font-family: var(--font-serif);
 }
 .project .description {
-  margin-top: 2px;
-  font-size: 20px;
-  line-height: 148%;
-  font-family: var(--font-body);
+  margin-top: 4px;
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-body);
+  color: var(--muted-foreground);
 }
 
 /* Back link */


### PR DESCRIPTION
Follow-up to #31. That PR matched the palette and font *families*; this one converges the **reading voice and layout chrome** so vislet reads as the same author's work as zamiang.com.

Per a design decision, the reading voice was flipped to match the sibling (sans body, serif headings) rather than preserving vislet's serif-body identity.

## Typography
- **Reading voice flipped:** body/prose is now **Lato (sans)**; **EB Garamond (serif)** is reserved for headings + editorial titles (`h1–h6`, project titles, author name, map headings, markdown headings).
- Adopt the sibling's **fluid `clamp()` type scale** (`--font-size-sm … 4xl`); body base `20px → 18px`; line-heights aligned (1.5 body / 1.7 prose).

## Layout & chrome
- Add the sibling's signature **paper-grain noise overlay** (`body::after`, opacity 0.025).
- Replace the dark `30×2px #333` `.border` bars with **4rem hairline rules** (`1px --border`), matching `.center-divider`.
- Uppercase section labels ("Featured Projects", "Created By") → **teal `--accent`** with tracking, echoing `.section-label`.
- Link hover color `--primary → --accent` (teal) to match the sibling.
- Reconcile remaining intro/author grays to tokens; markdown blockquote → 4px teal accent rule.

## Tokens & a11y
- Add `--secondary`, `--primary-foreground`, `--accent-foreground`, `--card`, `--accent-bold-hover`, the fluid scale, and reading-rhythm tokens.
- Add a `prefers-reduced-motion` block collapsing transitions/animations (the map-zoom `transform 0.5s`, slider, link underlines).

## Verification
- All four viz pages + home checked in-browser (1440px): consistent serif headings / sans body, teal labels, hairline dividers, paper grain. No console errors.
- **87/87** unit tests pass; `tsc` clean on touched files. `DESIGN.md` updated to the converged state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)