### PR TITLE
ci: grant write perms so Claude review/@claude can post comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write # needed to post the review as a PR comment (gh pr comment)
+      issues: write # PR comments are issue comments — also needs write
       id-token: write
 
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write # needed to post @claude replies/changes back to the PR
+      issues: write # issue/PR comments require write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Problem

Claude PR reviews never appear, even though the `Claude Code Review` workflow reports success.

Root cause: the `claude-review` job runs with a **read-only** `GITHUB_TOKEN`:

```
Contents: read   Issues: read   Metadata: read   PullRequests: read
```

The prompt tells Claude to post its review with `gh pr comment`, but a PR comment is an issue comment — posting one needs `pull-requests: write` (and `issues: write`). With read-only scopes the POST 403s, so the review is generated and dropped. The job still goes green because a failed `gh` call inside the agent doesn't fail the step. (Confirmed in run `27429376522`: `permission_denials_count: 14`, "No buffered inline comments".)

The `@claude` responder (`claude.yml`) had the same read-only perms, so it couldn't post replies either.

## Fix

Bump `pull-requests` and `issues` to `write` on both workflows.

## Safety

Fork safety is unchanged:
- `claude-code-review.yml` still gates on `author_association` (OWNER/MEMBER/COLLABORATOR).
- `anthropics/claude-code-action` independently verifies the triggering actor has repo write access before acting.

So a fork PR or drive-by `@claude` from a non-collaborator still can't get a write-scoped run.

> Note: because `pull_request` workflows run from the **base** branch's copy, this fix only takes effect once merged to `main` — the review on this PR itself still runs the old read-only version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)