### PR TITLE
fix: stacked-area charts (legend, overshoot, y-domain) for Brooklyn/311/Chicago

### DIFF
--- a/src/components/AreaChart.tsx
+++ b/src/components/AreaChart.tsx
@@ -6,8 +6,8 @@
  * was removed in v7). React renders the `<path>`s; D3 owns scales/shape/axes.
  */
 import {
-  curveCardinal,
   curveLinear,
+  curveMonotoneX,
   area as d3area,
   extent,
   format,
@@ -81,7 +81,11 @@ export function AreaChart({
     .range([height, 0])
     .domain(computeYDomain ? [0, areaYMax(series) * 1.3] : [0, 1]);
 
-  const curve = interpolate === 'cardinal' ? curveCardinal : curveLinear;
+  // `curveMonotoneX` for the smooth option, NOT `curveCardinal`: cardinal splines
+  // overshoot between points, which on a stacked area chart pushes a layer's
+  // boundary below its baseline (and below 0), rendering as phantom "negative"
+  // wedges. MonotoneX keeps the smooth look but never overshoots the data range.
+  const curve = interpolate === 'cardinal' ? curveMonotoneX : curveLinear;
   const areaPath = d3area<AreaPoint>()
     .curve(curve)
     .x((d) => x(d.date))

--- a/src/components/pages/Chicago.tsx
+++ b/src/components/pages/Chicago.tsx
@@ -28,6 +28,8 @@ const SLIDER_WIDTH = 502;
 const CHICAGO_ROTATE: [number, number] = [74 + 800 / 60, -38 - 50 / 60]; // [87.333, -39.833]
 const IGNORED_IDS = ['33', '20'];
 const DEFAULT_AREA = '7'; // Lincoln Park — pre-selected on load
+// Breakdown series excluded from the stacked chart (legacy chicago `ignoredIds`).
+const AREA_IGNORED_IDS = ['RIT', 'heat'];
 
 // ─── types ───────────────────────────────────────────────────────────────────
 
@@ -387,6 +389,10 @@ export function Chicago() {
                   height={CHART_HEIGHT}
                   label="Crime Type Breakdown"
                   keyLabel={areaKeyLabel}
+                  ignoredIds={AREA_IGNORED_IDS}
+                  computeYDomain
+                  yAxisFormat={(v) => String(v)}
+                  tooltipFormat=""
                   showTooltips
                 />
               )}

--- a/src/components/pages/ThreeOneOne.tsx
+++ b/src/components/pages/ThreeOneOne.tsx
@@ -20,6 +20,10 @@ import { parseGraphState, serializeGraphState } from '@/lib/url-state';
 import type { ColorDatum, DataPoint, ThreeOneOneData } from '@/types';
 
 const DEFAULT_AREA = 'BK60';
+// Breakdown series excluded from the stacked chart (legacy 311 `ignoredIds`).
+// `heat` (heating) is a massive outlier (peaks ~330 vs ~22 for the rest) that
+// would otherwise dominate the whole stack; `rode` (rodent) is also dropped.
+const AREA_IGNORED_IDS = ['rode', 'heat'];
 const MAP_WIDTH = 500;
 const MAP_HEIGHT = 400;
 const CHART_WIDTH = 490;
@@ -285,6 +289,10 @@ export function ThreeOneOne() {
               height={CHART_HEIGHT}
               label="Complaint Type Breakdown"
               keyLabel={keyLabel}
+              ignoredIds={AREA_IGNORED_IDS}
+              computeYDomain
+              yAxisFormat={(v) => String(v)}
+              tooltipFormat=""
               showTooltips
             />
           </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -380,6 +380,42 @@ body::after {
   color: var(--muted-foreground);
 }
 
+/* ==========================================================================
+   Categorical legend (Legend.tsx → `.graph-keys`), used by AreaChart for the
+   building-class / complaint-type / crime-type keys. Ported from the legacy
+   `components/graph-key/key.styl`, which was never migrated — so the
+   `.key-circle` swatches collapsed to 0×0 and the key rendered as a bare
+   vertical list of labels with no color. Flow into balanced columns with an
+   inline color swatch per entry.
+   ========================================================================== */
+.graph-keys {
+  font-size: 12px;
+  columns: 3 150px;
+  column-gap: 12px;
+  margin-top: 12px;
+}
+.graph-key {
+  display: flex;
+  align-items: flex-start;
+  gap: 5px;
+  max-height: 29px;
+  margin-bottom: 4px;
+  break-inside: avoid;
+}
+.key-circle {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  border-radius: 8px;
+  margin-top: 1px;
+}
+.key-text {
+  text-transform: capitalize;
+  line-height: 1.1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* Swatch backgrounds — Reds ramp (default: crime/311). Mirrors `.tract.colorN`. */
 .key-bar.color0 {
   background: #fee5d9;


### PR DESCRIPTION
Three rendering bugs in the migrated stacked-area / legend charts, all spotted on the live pages.

## 1. Categorical legend rendered with no color swatches
`Legend.tsx` (`.graph-keys` / `.key-circle` / `.key-text`) had **no CSS** — the legacy `components/graph-key/key.styl` was never ported, so the swatch `<div>`s collapsed to 0×0 and the key showed as a bare vertical list of labels (e.g. Brooklyn's "One Family Homes / Two Family Homes / …"). Ported the styles to `globals.css`: 3-column flow with an inline 16×16 rounded swatch per entry. Shared by Brooklyn, 311, Chicago.

## 2. Stacked area showed phantom "negative" wedges (curve overshoot)
`AreaChart` used `curveCardinal`, which overshoots between points. On a *stacked* chart that pushes a layer's boundary below its baseline (and below 0). Switched the smooth curve to `curveMonotoneX` — same look, no overshoot.

## 3. 311 + Chicago breakdown charts squished/clipped (dropped options)
The migration dropped four options the legacy `StackedGraph` passed (`apps/{311,chicago}/client/index.coffee`):

| option | legacy | why it matters |
|---|---|---|
| `computeYDomain` | `true` | Without it the y-domain defaults to `[0,1]` (percent), but the data is raw counts. Stacked totals reach ~22 (311) / ~45 (Chicago), so everything was clipped into the bottom sliver. |
| `ignoredIds` | 311 `['rode','heat']`, Chicago `['RIT','heat']` | 311's `heat` (heating) peaks at ~330 vs ~22 for all other series combined — including it made the stacked max **352** and buried everything else. |
| `yAxisFormat` | `(x) => x` | Default percent formatter mislabeled raw counts as percentages. |
| `tooltipFormat` | `""` | Default `" %"` suffix is wrong for counts. |

Verified against the data: excluding `rode`/`heat` drops the 311 stacked max from **352.68 → 22.23**; `computeYDomain` then scales the axis to `[0, ~29]`. Both charts now stack cleanly from 0 to their real totals with every series visible.

## Verification
- `tsc --noEmit` clean, eslint clean, prettier clean, 87/87 Vitest tests pass.
- Browser-confirmed all three: Brooklyn legend swatches, 311 + Chicago breakdown charts rendering full-height with correct raw-count axes.

## Not included (follow-ups discussed)
- `LineGraph` uses the same `curveCardinal` and can also dip below 0 — left as-is (only stacked charts were reported).
- Legacy line/area charts animated their path morphs; dropped in the React port. Restoring it is a separate, non-trivial change (path-`d` interpolation). Map fill colors never animated in legacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)