### PR TITLE
feat: animate chart path morphs via CSS transition on `d`

### DIFF
--- a/src/components/AreaChart.tsx
+++ b/src/components/AreaChart.tsx
@@ -105,7 +105,7 @@ export function AreaChart({
               <path
                 className="area"
                 d={areaPath(s.values) ?? undefined}
-                style={{ fill: color(s.name) }}
+                style={{ fill: color(s.name), transition: 'd 0.5s ease' }}
               />
             </g>
           ))}

--- a/src/components/AreaChart.tsx
+++ b/src/components/AreaChart.tsx
@@ -6,8 +6,8 @@
  * was removed in v7). React renders the `<path>`s; D3 owns scales/shape/axes.
  */
 import {
-  curveCardinal,
   curveLinear,
+  curveMonotoneX,
   area as d3area,
   extent,
   format,
@@ -81,7 +81,11 @@ export function AreaChart({
     .range([height, 0])
     .domain(computeYDomain ? [0, areaYMax(series) * 1.3] : [0, 1]);
 
-  const curve = interpolate === 'cardinal' ? curveCardinal : curveLinear;
+  // `curveMonotoneX` for the smooth option, NOT `curveCardinal`: cardinal splines
+  // overshoot between points, which on a stacked area chart pushes a layer's
+  // boundary below its baseline (and below 0), rendering as phantom "negative"
+  // wedges. MonotoneX keeps the smooth look but never overshoots the data range.
+  const curve = interpolate === 'cardinal' ? curveMonotoneX : curveLinear;
   const areaPath = d3area<AreaPoint>()
     .curve(curve)
     .x((d) => x(d.date))

--- a/src/components/LineGraph.tsx
+++ b/src/components/LineGraph.tsx
@@ -18,6 +18,7 @@ import {
   scaleTime,
   timeYear,
 } from 'd3';
+import type { CSSProperties } from 'react';
 
 import { Axis } from '@/components/Axis';
 import { Legend, type LegendEntry } from '@/components/Legend';
@@ -32,6 +33,17 @@ import {
 import type { DataPoint, Margin, Series, TrendPoint } from '@/types';
 
 const DEFAULT_MARGIN: Margin = { top: 10, left: 50, right: 0, bottom: 20 };
+
+/**
+ * Animate the path morph when the underlying data changes (e.g. switching
+ * neighborhoods). Series are keyed by name (`getFlattenedData` keys by series,
+ * not by selection) and every neighborhood has the same point count, so the
+ * `<path>` element persists with a stable `d` command structure — the browser
+ * tweens between the old and new `d`. Mirrors SvgMap's CSS-transition approach
+ * (no `d3.select(...).transition()` mutating a React-owned node); legacy used a
+ * 500ms transition. Browsers without CSS `d` animation just snap (no breakage).
+ */
+const PATH_TRANSITION: CSSProperties = { transition: 'd 0.5s ease' };
 
 export interface LineGraphProps {
   data: LineGraphData;
@@ -108,12 +120,16 @@ export function LineGraph({
           {lines.map((line) => (
             <g className="sales" key={line.name}>
               {displayTrend && hasTrend(line.values) && (
-                <path className="trend-area" d={trendArea(line.values) ?? undefined} />
+                <path
+                  className="trend-area"
+                  d={trendArea(line.values) ?? undefined}
+                  style={PATH_TRANSITION}
+                />
               )}
               <path
                 className="line"
                 d={linePath(line.values) ?? undefined}
-                style={{ stroke: lineColor(line.name) }}
+                style={{ stroke: lineColor(line.name), ...PATH_TRANSITION }}
               />
               {displayLineLabels && <LineLabel line={line} x={x} y={y} />}
             </g>

--- a/src/components/pages/Chicago.tsx
+++ b/src/components/pages/Chicago.tsx
@@ -28,6 +28,8 @@ const SLIDER_WIDTH = 502;
 const CHICAGO_ROTATE: [number, number] = [74 + 800 / 60, -38 - 50 / 60]; // [87.333, -39.833]
 const IGNORED_IDS = ['33', '20'];
 const DEFAULT_AREA = '7'; // Lincoln Park — pre-selected on load
+// Breakdown series excluded from the stacked chart (legacy chicago `ignoredIds`).
+const AREA_IGNORED_IDS = ['RIT', 'heat'];
 
 // ─── types ───────────────────────────────────────────────────────────────────
 
@@ -387,6 +389,10 @@ export function Chicago() {
                   height={CHART_HEIGHT}
                   label="Crime Type Breakdown"
                   keyLabel={areaKeyLabel}
+                  ignoredIds={AREA_IGNORED_IDS}
+                  computeYDomain
+                  yAxisFormat={(v) => String(v)}
+                  tooltipFormat=""
                   showTooltips
                 />
               )}

--- a/src/components/pages/ThreeOneOne.tsx
+++ b/src/components/pages/ThreeOneOne.tsx
@@ -20,6 +20,10 @@ import { parseGraphState, serializeGraphState } from '@/lib/url-state';
 import type { ColorDatum, DataPoint, ThreeOneOneData } from '@/types';
 
 const DEFAULT_AREA = 'BK60';
+// Breakdown series excluded from the stacked chart (legacy 311 `ignoredIds`).
+// `heat` (heating) is a massive outlier (peaks ~330 vs ~22 for the rest) that
+// would otherwise dominate the whole stack; `rode` (rodent) is also dropped.
+const AREA_IGNORED_IDS = ['rode', 'heat'];
 const MAP_WIDTH = 500;
 const MAP_HEIGHT = 400;
 const CHART_WIDTH = 490;
@@ -285,6 +289,10 @@ export function ThreeOneOne() {
               height={CHART_HEIGHT}
               label="Complaint Type Breakdown"
               keyLabel={keyLabel}
+              ignoredIds={AREA_IGNORED_IDS}
+              computeYDomain
+              yAxisFormat={(v) => String(v)}
+              tooltipFormat=""
               showTooltips
             />
           </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -380,6 +380,42 @@ body::after {
   color: var(--muted-foreground);
 }
 
+/* ==========================================================================
+   Categorical legend (Legend.tsx → `.graph-keys`), used by AreaChart for the
+   building-class / complaint-type / crime-type keys. Ported from the legacy
+   `components/graph-key/key.styl`, which was never migrated — so the
+   `.key-circle` swatches collapsed to 0×0 and the key rendered as a bare
+   vertical list of labels with no color. Flow into balanced columns with an
+   inline color swatch per entry.
+   ========================================================================== */
+.graph-keys {
+  font-size: 12px;
+  columns: 3 150px;
+  column-gap: 12px;
+  margin-top: 12px;
+}
+.graph-key {
+  display: flex;
+  align-items: flex-start;
+  gap: 5px;
+  max-height: 29px;
+  margin-bottom: 4px;
+  break-inside: avoid;
+}
+.key-circle {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  border-radius: 8px;
+  margin-top: 1px;
+}
+.key-text {
+  text-transform: capitalize;
+  line-height: 1.1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* Swatch backgrounds — Reds ramp (default: crime/311). Mirrors `.tract.colorN`. */
 .key-bar.color0 {
   background: #fee5d9;


### PR DESCRIPTION
Option A from the chart-animation investigation: restore the data-change animation the legacy line/area charts had (`.transition().duration(500)`), the non-disruptive way.

> Stacked on #37 (legend + stacked-area fixes). Base will auto-retarget to `main` once #37 merges.

## Approach
Add `transition: d 0.5s ease` to the line and area `<path>` elements. The browser tweens the `d` morph — **no `d3.select(...).transition()` mutating a React-owned node**, so it honors the repo's "React owns the DOM" rule and mirrors `SvgMap`'s existing CSS-transition (zoom) pattern.

## Why it works (verified)
- **Element persists across a selection change.** Series are keyed by name (`getFlattenedData` keys by series, not by neighborhood), so React updates the same `<path>` in place rather than remounting it. Confirmed in-browser: the path node persists (`samePersistedNode: true`) with a changed `d` after switching neighborhoods.
- **Stable command structure.** Every Brooklyn neighborhood has 48 points, every 311 neighborhood 60 — identical path command count before/after, so the browser interpolates instead of snapping.
- Computed style confirmed `d 0.5s` on both `path.line` and `path.area`.

## Trade-offs
- The y-axis ticks still snap (legacy tweened those too). Animating the axis/y-domain needs the d3-interpolate `TweenPath` hook (option B) — a deliberate follow-up, not included here.
- Safari < 16 / Firefox < 97 don't animate CSS `d` and just snap. Graceful, no breakage.

## Verification
`tsc` clean, eslint clean, prettier clean, 87/87 Vitest tests pass. In-browser: transition applied + path-node persistence confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)