### PR TITLE
ci: allow Read/Grep/Glob so Claude review can actually post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -63,6 +63,13 @@ jobs:
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
+          # Surface Claude's output in the run log so silent failures (e.g.
+          # permission denials) are visible instead of hidden behind a green check.
+          show_full_output: true
+
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          # Read/Grep/Glob are required: the prompt asks Claude to review against
+          # CLAUDE.md and docs/, and without them every file read is denied and
+          # the review dies before posting anything.
+          claude_args: '--allowed-tools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## Why

The Claude Code Review workflow has shown green on every PR (#34–#37) but has never posted a single review comment. Run logs show why: the action's `--allowed-tools` list contained only `gh` command patterns, while the prompt asks Claude to review against `CLAUDE.md`, `docs/MIGRATION.md`, and `docs/ARCHITECTURE.md`. Every `Read`/`Grep`/`Glob` call was denied (e.g. PR #37's run ended with `permission_denials_count: 13`), and the agent gave up before ever running `gh pr comment`. The action still exits 0, so the check stayed green.

The earlier fix in #36 addressed the GitHub-token side (`pull-requests: write`) but not this layer — Claude Code's own tool allowlist.

## What

- Add `Read,Grep,Glob` to `--allowed-tools` in `claude-code-review.yml` (these are read-only tools).
- Set `show_full_output: true` so future in-run failures are visible in the workflow log instead of hidden behind a green check.

## Verification

This workflow runs on this PR itself (`pull_request: opened`) — a Claude review comment appearing below is the test passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)