### PR TITLE
fix: homepage AA contrast + semantic structure (a11y polish)

### DIFF
--- a/__tests__/e2e/smoke.spec.ts
+++ b/__tests__/e2e/smoke.spec.ts
@@ -20,10 +20,19 @@ test.describe('Home page (/)', () => {
     const response = await page.goto('/', { waitUntil: 'networkidle' });
 
     expect(response?.status()).toBe(200);
-    await expect(page.getByText('VISLET')).toBeVisible();
-    await expect(page.getByRole('link', { name: /Brooklyn Property Sales/i })).toBeVisible();
-    await expect(page.getByRole('link', { name: /NYC 311/i })).toBeVisible();
-    await expect(page.getByRole('link', { name: /Chicago Crime/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'VISLET' })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1 })).toHaveCount(1);
+
+    // Header nav and the featured-projects list link to the same pages, so
+    // scope each assertion to its landmark to avoid strict-mode ambiguity.
+    const nav = page.getByRole('navigation', { name: 'Visualizations' });
+    await expect(nav.getByRole('link', { name: /NYC 311/i })).toBeVisible();
+    await expect(nav.getByRole('link', { name: /Chicago Crime/i })).toBeVisible();
+
+    const projects = page.locator('.project-list');
+    await expect(projects.getByRole('link', { name: /Brooklyn Property Sales/i })).toBeVisible();
+    await expect(projects.getByRole('link', { name: /NYC 311/i })).toBeVisible();
+    await expect(projects.getByRole('link', { name: /Chicago Crime/i })).toBeVisible();
 
     expect(getErrors()).toHaveLength(0);
   });

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -52,6 +52,7 @@ const canonical = Astro.url.href;
     <slot name="head" />
   </head>
   <body class="font-sans bg-background text-foreground">
+    <a class="skip-link" href="#main-content">Skip to content</a>
     <div id="main-layout-container">
       {/* Shared intro/header — ported from header/intro.jade */}
       <header class="vislet-intro">
@@ -59,7 +60,7 @@ const canonical = Astro.url.href;
         <p class="about">
           Small interactive visualizations to help us understand the cities we live in.
         </p>
-        <nav class="items">
+        <nav class="items" aria-label="Visualizations">
           {
             config.nav.map((item) => (
               <a class="faux-underline-hover" href={item.href}>
@@ -70,7 +71,7 @@ const canonical = Astro.url.href;
         </nav>
       </header>
 
-      <main>
+      <main id="main-content">
         <slot />
       </main>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,17 +35,24 @@ const projects = [
 
 <BaseLayout>
   <div id="home">
+    <h1 class="visually-hidden">
+      Vislet — small interactive visualizations of the cities we live in
+    </h1>
     <div class="projects">
-      <div class="project-title">Featured Projects</div>
+      <h2 class="project-title">Featured Projects</h2>
       <div class="border"></div>
-      {
-        projects.map((project) => (
-          <a class="project faux-underline-hover" href={project.href}>
-            <div class="title faux-underline-large">{project.name}</div>
-            <div class="description">{project.description}</div>
-          </a>
-        ))
-      }
+      <ul class="project-list">
+        {
+          projects.map((project) => (
+            <li>
+              <a class="project faux-underline-hover" href={project.href}>
+                <h3 class="title faux-underline-large">{project.name}</h3>
+                <p class="description">{project.description}</p>
+              </a>
+            </li>
+          ))
+        }
+      </ul>
     </div>
   </div>
 </BaseLayout>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -12,6 +12,7 @@
   --color-primary: var(--primary);
   --color-secondary: var(--secondary);
   --color-accent: var(--accent);
+  --color-accent-deep: var(--accent-deep);
   --color-accent-bold: var(--accent-bold);
   --color-border: var(--border);
   /* Shared "Slate Executive" type voice with zamiang-dot-com-v2: Lato (sans)
@@ -35,6 +36,7 @@
   --primary-foreground: #f0f2f5;
   --secondary: #e3e7eb; /* Lighter mist for secondary surfaces */
   --accent: #749ca8; /* Dusty Teal — links, labels, accents */
+  --accent-deep: #4f6d78; /* Dusty Teal darkened for text on Cool Mist (4.94:1 AA) */
   --accent-foreground: #2c333a;
   --accent-bold: #c17f59; /* Warm Copper — the only warm color */
   --accent-bold-hover: #d4906a;
@@ -149,8 +151,55 @@ body::after {
 }
 .faux-underline-large:hover,
 .faux-underline-hover:hover,
-.faux-underline-hover.active {
+.faux-underline-hover.active,
+.faux-underline-large:focus-visible,
+.faux-underline-hover:focus-visible {
   text-decoration-color: var(--accent);
+}
+/* Block links (project cards): hovering or keyboard-focusing the link lights
+   the title's underline, since the wrapper itself draws no decoration. */
+.faux-underline-hover:hover .faux-underline-large,
+.faux-underline-hover:focus-visible .faux-underline-large {
+  text-decoration-color: var(--accent);
+}
+
+/* Keyboard focus — one consistent ring across browsers, paired with the same
+   teal underline the pointer hover gets. --accent-deep clears both the 3:1
+   non-text and 4.5:1 text thresholds on Cool Mist. */
+a:focus-visible {
+  outline: 2px solid var(--accent-deep);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+/* Skip link — visually hidden until keyboard-focused. */
+.skip-link {
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, -150%);
+  top: 8px;
+  z-index: 10000;
+  padding: 8px 16px;
+  background: var(--foreground);
+  color: var(--background);
+  border-radius: 4px;
+  text-decoration: none;
+  transition: transform var(--transition-fast) var(--ease-out);
+}
+.skip-link:focus-visible {
+  transform: translate(-50%, 0);
+}
+
+/* Screen-reader-only text (page h1 on the homepage). */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
 }
 
 /* ---- vislet-intro header ---- */
@@ -210,7 +259,7 @@ body::after {
   letter-spacing: var(--tracking-caps);
   text-transform: uppercase;
   font-size: 13px;
-  color: var(--accent);
+  color: var(--accent-deep);
   margin-top: 26px;
   margin-bottom: 10px;
 }
@@ -687,7 +736,12 @@ body::after {
   letter-spacing: var(--tracking-caps);
   font-weight: 600;
   font-size: var(--font-size-sm);
-  color: var(--accent);
+  color: var(--accent-deep);
+}
+.project-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 .projects > .border {
   width: 4rem;
@@ -703,13 +757,14 @@ body::after {
   color: inherit;
 }
 .project .title {
+  margin: 0;
   font-size: var(--font-size-2xl);
   line-height: 1.3;
   font-weight: 600;
   font-family: var(--font-serif);
 }
 .project .description {
-  margin-top: 0.5rem;
+  margin: 0.5rem 0 0;
   font-size: var(--font-size-base);
   line-height: var(--line-height-body);
   color: var(--muted-foreground);


### PR DESCRIPTION
## Summary

First fix batch from the `/impeccable critique` of the homepage (snapshot: `.impeccable/critique/2026-06-13T01-29-25Z__src-pages-index-astro.md`, score 26/40). Addresses the P1 contrast failure and the P2 semantics items.

- **AA contrast**: new `--accent-deep: #4f6d78` token (4.94:1 on Cool Mist `#f0f2f5`) replaces `--accent #749ca8` (2.65:1) on the "Featured Projects" / "Created By" labels. Audit result: `--primary #5a7684` (4.30:1) never renders as text in `src/` — only SVG fills/handles/swatches, which are non-text (3:1) and pass.
- **Semantic structure**: visually-hidden `h1` on the homepage, `h2` section label, project titles as `h3` inside a `ul`; `aria-label` on the header nav.
- **Skip link**: hidden until keyboard focus, jumps to `#main-content`.
- **`:focus-visible`**: teal underline mirroring hover + 2px `--accent-deep` ring; block project links light their title underline on hover *and* keyboard focus (hovering the description now highlights the title too).
- **Smoke test fix (pre-existing)**: the home test's `getByText('VISLET')` / unscoped link-name lookups strict-mode-collide because the header nav and project list share link names — it fails on `main` once the first assertion is reachable. Assertions are now scoped to their landmarks, plus a single-`h1` check.

## Verification

- 14/14 Playwright smoke tests, `tsc --noEmit` clean, Vitest 87/87 (the one brooklyn-aggregate failure in the dirty tree comes from unrelated in-progress ETL data, passes against committed data).
- Headless Chromium keyboard walkthrough: skip link appears on first Tab and jumps to main; focus rings and teal underlines verified post-transition.
- Computed label color in-browser is `rgb(79, 109, 120)`; visual layout unchanged vs the pre-change render at 1440px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)